### PR TITLE
Fixes project resolve age updating

### DIFF
--- a/resource_sentry_project.go
+++ b/resource_sentry_project.go
@@ -98,6 +98,9 @@ func resourceSentryProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	params := &UpdateProjectParams{
 		Name: d.Get("name").(string),
 		Slug: d.Get("slug").(string),
+		Options: UpdateProjectOptionsParams{
+			ResolveAge: d.Get("resolve_age").(int),
+		},
 	}
 
 	proj, _, err := client.UpdateProject(org, slug, params)


### PR DESCRIPTION
Previously the resolve age was never send when updating the project
resurce causing plan to always display changes to apply.