### PR TITLE
Clarifying import help text for projects

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -177,7 +177,7 @@ func resourceSentryProjectImporter(d *schema.ResourceData, meta interface{}) ([]
 	parts := strings.Split(addrID, "/")
 
 	if len(parts) != 2 {
-		return nil, errors.New("Project import requires an ADDR ID of the following schema org-slug/team-slug")
+		return nil, errors.New("Project import requires an ADDR ID of the following schema org-slug/project-slug")
 	}
 
 	d.Set("organization", parts[0])


### PR DESCRIPTION
## Summary

When importing a Sentry project into my state file, I noticed that the help text incorrectly prompts to the user for the `team-slug` instead of the `project-slug`.