### PR TITLE
Added documentation for the sentry_key resource and data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,42 @@ The following attributes are exported:
 
 * `id` - The ID of the created project.
 
+#### `sentry_key`
+
+##### Example Usage
+
+```
+# Create a key
+resource "sentry_key" "default" {
+    organization = "my-organization"
+    project = "web-app"
+    name = "My Key"
+}
+```
+
+##### Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) The slug of the organization the key should be created for.
+* `project` - (Required) The slug of the project the key should be created for.
+* `name` - (Required) The name of the key.
+
+##### Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the created key.
+* `public` - Public key portion of the client key.
+* `secret` - Secret key portion of the client key.
+* `project_id` - The ID of the project that the key belongs to.
+* `is_active` - Flag indicating the key is active.
+* `rate_limit_window` - Length of time that will be considered when checking the rate limit.
+* `rate_limit_count` - Number of events that can be reported within the rate limit window.
+* `dsn_secret` - DSN (Deprecated) for the key.
+* `dsn_public` - DSN for the key.
+* `dsn_csp` - DSN for the Content Security Policy (CSP) for the key.
+
 #### `sentry_plugin`
 
 ##### Example Usage
@@ -146,6 +182,45 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the created plugin.
+
+### Data Source Configuration
+
+#### `sentry_key`
+
+##### Example Usage
+
+```
+# Retrieve the Default Key
+data "sentry_key" "default" {
+    organization = "my-organization"
+    project = "web-app"
+    name = "Default"
+}
+```
+
+##### Argument Reference
+
+The following arguments are supported:
+
+* `organization` - (Required) The slug of the organization the key should be created for.
+* `project` - (Required) The slug of the project the key should be created for.
+* `name` - (Optional) The name of the key to retrieve.
+* `first` - (Optional) Boolean flag indicating that we want the first key of the returned keys.
+
+##### Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the created key.
+* `public` - Public key portion of the client key.
+* `secret` - Secret key portion of the client key.
+* `project_id` - The ID of the project that the key belongs to.
+* `is_active` - Flag indicating the key is active.
+* `rate_limit_window` - Length of time that will be considered when checking the rate limit.
+* `rate_limit_count` - Number of events that can be reported within the rate limit window.
+* `dsn_secret` - DSN (Deprecated) for the key.
+* `dsn_public` - DSN for the key.
+* `dsn_csp` - DSN for the Content Security Policy (CSP) for the key.
 
 ### Import
 


### PR DESCRIPTION
I recently used your terraform plugin and initially ran into trouble thinking that it did not support the client keys. I would like to update the readme to document the resource and data source for the client keys.