### PR TITLE
Add project key rate limit

### DIFF
--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -94,6 +94,16 @@ func resourceSentryKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(key.ID)
+
+	if params.RateLimit != nil {
+		// RateLimit is currently only supported in an Update API call
+		err := resourceSentryKeyUpdate(d, meta)
+
+		if err != nil {
+			return err
+		}
+	}
+
 	return resourceSentryKeyRead(d, meta)
 }
 

--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -82,6 +82,10 @@ func resourceSentryKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	project := d.Get("project").(string)
 	params := &sentry.CreateProjectKeyParams{
 		Name: d.Get("name").(string),
+		RateLimit: &sentry.ProjectKeyRateLimit{
+			Window: d.Get("rate_limit_window").(int),
+			Count:  d.Get("rate_limit_count").(int),
+		},
 	}
 
 	key, _, err := client.ProjectKeys.Create(org, project, params)

--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -51,10 +51,12 @@ func resourceSentryKey() *schema.Resource {
 			},
 			"rate_limit_window": {
 				Type:     schema.TypeInt,
+				Optional: true,
 				Computed: true,
 			},
 			"rate_limit_count": {
 				Type:     schema.TypeInt,
+				Optional: true,
 				Computed: true,
 			},
 			"dsn_secret": {
@@ -147,6 +149,10 @@ func resourceSentryKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 	project := d.Get("project").(string)
 	params := &sentry.UpdateProjectKeyParams{
 		Name: d.Get("name").(string),
+		RateLimit: &sentry.ProjectKeyRateLimit{
+			Window: d.Get("rate_limit_window").(int),
+			Count:  d.Get("rate_limit_count").(int),
+		},
 	}
 
 	key, _, err := client.ProjectKeys.Update(org, project, id, params)

--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -95,15 +95,6 @@ func resourceSentryKeyCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(key.ID)
 
-	if params.RateLimit != nil {
-		// RateLimit is currently only supported in an Update API call
-		err := resourceSentryKeyUpdate(d, meta)
-
-		if err != nil {
-			return err
-		}
-	}
-
 	return resourceSentryKeyRead(d, meta)
 }
 


### PR DESCRIPTION
NOTE: This depends upon the following PR for `go-sentry` and a corresponding update to vendor files: https://github.com/jianyuan/go-sentry/pull/2

Lets users optionally supply rate limits when creating project keys:
```
resource "sentry_key" "test_key_rate_limit" {
    organization = "widget-corp"
    project = "hello-world"
    name = "Test key"
    rate_limit_window = 86400
    rate_limit_count = 1000
}
```