### PR TITLE
Read removed rules should'nt return error

### DIFF
--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -1,8 +1,6 @@
 package sentry
 
 import (
-	"errors"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
 	"github.com/mitchellh/mapstructure"
@@ -150,7 +148,8 @@ func resourceSentryRuleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if rule == nil {
-		return errors.New("Could not find rule with ID " + id)
+		d.SetId("")
+		return nil
 	}
 
 	d.SetId(rule.ID)


### PR DESCRIPTION
Reading a deleted rules return an error. It should only return nil with an empty ID.

Step to reproduce:
- deploy rules with terraform
- remove rules manually
- rerun terraform