### PR TITLE
Add additional variables to sentry_rule resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,22 @@ resource "sentry_rule" "default" {
     frequency    = 30
     environment  = "production"
 
-    actions = [{
-        id = "sentry.rules.actions.notify_event.NotifyEventAction"
-    }]
+    conditions = [
+      {
+        id       = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
+        value    = 500
+        interval = "1h"
+      }
+    ]
 
-    conditions = [{
-        id = "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
-    }]
-}
+    actions = [
+      {
+        id        = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
+        channel   = "#alerts"
+        workspace = "12345"
+      }
+    ]
+  }
 ```
 
 ##### Argument Reference

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk v1.7.0
 	github.com/hashicorp/terraform-svchost v0.0.0-20191119180714-d2e4933b9136 // indirect
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
-	github.com/jianyuan/go-sentry v1.2.1-0.20191201111848-212d47039109
+	github.com/jianyuan/go-sentry v1.2.1-0.20200311212600-e08136b4029f
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/oklog/run v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,8 @@ github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d/go.mod h1:+NfK9FKe
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jianyuan/go-sentry v1.2.1-0.20191201111848-212d47039109 h1:vNC97hHywvxBBDosxyYMsA2/5wW3lZ2n9NVTXSkF+Nw=
 github.com/jianyuan/go-sentry v1.2.1-0.20191201111848-212d47039109/go.mod h1:IlgHIblLdlWCnqpIxFV4bnLb4fgg9xFfDd41p6kRc/Y=
+github.com/jianyuan/go-sentry v1.2.1-0.20200311212600-e08136b4029f h1:3e19LdlWVXSXimLTE96R5dQC7KS7s0Lg6gCX3jNa8sQ=
+github.com/jianyuan/go-sentry v1.2.1-0.20200311212600-e08136b4029f/go.mod h1:IlgHIblLdlWCnqpIxFV4bnLb4fgg9xFfDd41p6kRc/Y=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 h1:12VvqtR6Aowv3l/EQUlocDHW2Cp4G9WJVH7uyH8QFJE=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=

--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -96,13 +96,13 @@ func resourceSentryRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	conditions := make([]*sentry.CreateRuleConditionParams, len(inputConditions))
 	for i, ic := range inputConditions {
 		var condition sentry.CreateRuleConditionParams
-		mapstructure.Decode(ic, &condition)
+		mapstructure.WeakDecode(ic, &condition)
 		conditions[i] = &condition
 	}
 	actions := make([]*sentry.CreateRuleActionParams, len(inputActions))
 	for i, ia := range inputActions {
 		var action sentry.CreateRuleActionParams
-		mapstructure.Decode(ia, &action)
+		mapstructure.WeakDecode(ia, &action)
 		actions[i] = &action
 	}
 
@@ -199,7 +199,7 @@ func resourceSentryRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	params := &sentry.Rule{
 		ID:          id,
 		ActionMatch: actionMatch,
-		Environment: environment,
+		Environment: &environment,
 		Frequency:   frequency,
 		Name:        name,
 		Conditions:  conditions,
@@ -207,7 +207,7 @@ func resourceSentryRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if environment != "" {
-		params.Environment = environment
+		params.Environment = &environment
 	}
 
 	_, _, err := client.Rules.Update(org, project, id, params)


### PR DESCRIPTION
## Overview 

This updates go-sentry to the latest master commit [containing changes](https://github.com/jianyuan/go-sentry/pull/10) to support addition variable rules. It also changes the usage of `mapstructure.Decode` to  `mapstructure.WeakDecode` to allow for parameters to be optional, and avoid issues with type conversions coming from HCL.

There's also a quick fix for a bug preventing builds on master included due to the wrong type being used.

## Example Usage

```terraform
resource "sentry_rule" "excessive_errors" {
  name         = "Excessive Errors"
  organization = "myorg"
  project      = "myapp"
  environment  = "production"

  action_match = "all"
  frequency    = 30

  conditions = [
    {
      id       = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
      value    = 500
      interval = "1h"
    }
  ]

  actions = [
    {
      id        = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
      channel   = "#alerts"
      workspace = "12345"
    }
  ]
}
```