### PR TITLE
Runs a project update right after it has been created

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -105,6 +105,7 @@ func resourceSentryProjectCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(proj.Slug)
+	resourceSentryProjectUpdate(d, meta)
 	return resourceSentryProjectRead(d, meta)
 }
 

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -105,8 +105,7 @@ func resourceSentryProjectCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	d.SetId(proj.Slug)
-	resourceSentryProjectUpdate(d, meta)
-	return resourceSentryProjectRead(d, meta)
+	return resourceSentryProjectUpdate(d, meta)
 }
 
 func resourceSentryProjectRead(d *schema.ResourceData, meta interface{}) error {

--- a/sentry/resource_sentry_project_test.go
+++ b/sentry/resource_sentry_project_test.go
@@ -28,6 +28,7 @@ func TestAccSentryProject_basic(t *testing.T) {
 	    team = "${sentry_team.test_team.id}"
 	    name = "Test project changed"
 	    slug = "%s"
+	    platform = "go"
 	  }
 	`, testOrganization, testOrganization, newProjectSlug)
 
@@ -45,6 +46,7 @@ func TestAccSentryProject_basic(t *testing.T) {
 						Organization: testOrganization,
 						Team:         "Test team",
 						SlugPresent:  true,
+						Platform:     "go",
 					}),
 				),
 			},
@@ -57,6 +59,7 @@ func TestAccSentryProject_basic(t *testing.T) {
 						Organization: testOrganization,
 						Team:         "Test team",
 						Slug:         newProjectSlug,
+						Platform:     "go",
 					}),
 				),
 			},
@@ -117,6 +120,7 @@ type testAccSentryProjectExpectedAttributes struct {
 
 	SlugPresent bool
 	Slug        string
+	Platform    string
 }
 
 func testAccCheckSentryProjectAttributes(proj *sentry.Project, want *testAccSentryProjectExpectedAttributes) resource.TestCheckFunc {
@@ -141,6 +145,10 @@ func testAccCheckSentryProjectAttributes(proj *sentry.Project, want *testAccSent
 			return fmt.Errorf("got slug %q; want %q", proj.Slug, want.Slug)
 		}
 
+		if want.Platform != "" && proj.Platform != want.Platform {
+			return fmt.Errorf("got Platform %q; want %q", proj.Platform, want.Platform)
+		}
+
 		return nil
 	}
 }
@@ -155,5 +163,6 @@ var testAccSentryProjectConfig = fmt.Sprintf(`
     organization = "%s"
     team = "${sentry_team.test_team.id}"
     name = "Test project"
+    platform = "go"
   }
 `, testOrganization, testOrganization)


### PR DESCRIPTION
This fix tries to solve #54 .

Since the create endpoint of Sentry API only allows  the name for a new project, this change will update the resource to add the other properties.