### PR TITLE
Make token not required so that env var can be used

### DIFF
--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -11,7 +11,7 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"token": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SENTRY_TOKEN", nil),
 				Description: "The authentication token used to connect to Sentry",
 			},


### PR DESCRIPTION
You can see how TFE provider does it [here](https://github.com/terraform-providers/terraform-provider-tfe/blob/master/tfe/provider.go#L58)