### PR TITLE
Introduce `checkClientGet` for 404 handling

### DIFF
--- a/sentry/helpers.go
+++ b/sentry/helpers.go
@@ -1,5 +1,11 @@
 package sentry
 
+import (
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
 // Bool returns a pointer to the bool value.
 func Bool(v bool) *bool {
 	return &v
@@ -8,4 +14,22 @@ func Bool(v bool) *bool {
 // Int returns a pointer to the int value.
 func Int(v int) *int {
 	return &v
+}
+
+// checkClientGet returns a `found` bool and an `error` to indicate if a Get request was successful.
+// The following return values are meaningful:
+// `true`, `nil` => a resource was successfully found
+// `false`, `nil` => a resource was successfully not found
+// `false`, `err` => encountered an unexpected error
+func checkClientGet(resp *http.Response, err error, d *schema.ResourceData) (bool, error) {
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }

--- a/sentry/resource_sentry_key.go
+++ b/sentry/resource_sentry_key.go
@@ -1,8 +1,6 @@
 package sentry
 
 import (
-	"net/http"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
 )
@@ -106,10 +104,7 @@ func resourceSentryKeyRead(d *schema.ResourceData, meta interface{}) error {
 	project := d.Get("project").(string)
 
 	keys, resp, err := client.ProjectKeys.List(org, project)
-	if err != nil && resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
-	} else if err != nil {
+	if found, err := checkClientGet(resp, err, d); !found {
 		return err
 	}
 

--- a/sentry/resource_sentry_organization.go
+++ b/sentry/resource_sentry_organization.go
@@ -63,10 +63,9 @@ func resourceSentryOrganizationRead(d *schema.ResourceData, meta interface{}) er
 	slug := d.Id()
 	log.Printf("[DEBUG] Reading Sentry organization %s", slug)
 
-	org, _, err := client.Organizations.Get(slug)
-	if err != nil {
-		d.SetId("")
-		return nil
+	org, resp, err := client.Organizations.Get(slug)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return err
 	}
 
 	d.SetId(org.Slug)

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -114,10 +114,9 @@ func resourceSentryProjectRead(d *schema.ResourceData, meta interface{}) error {
 	slug := d.Id()
 	org := d.Get("organization").(string)
 
-	proj, _, err := client.Projects.Get(org, slug)
-	if err != nil {
-		d.SetId("")
-		return nil
+	proj, resp, err := client.Projects.Get(org, slug)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return err
 	}
 
 	d.SetId(proj.Slug)

--- a/sentry/resource_sentry_project_plugin.go
+++ b/sentry/resource_sentry_project_plugin.go
@@ -72,10 +72,9 @@ func resourceSentryPluginRead(d *schema.ResourceData, meta interface{}) error {
 	org := d.Get("organization").(string)
 	project := d.Get("project").(string)
 
-	plugin, _, err := client.ProjectPlugins.Get(org, project, id)
-	if err != nil {
-		d.SetId("")
-		return nil
+	plugin, resp, err := client.ProjectPlugins.Get(org, project, id)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return err
 	}
 
 	d.SetId(plugin.ID)

--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -135,10 +135,9 @@ func resourceSentryRuleRead(d *schema.ResourceData, meta interface{}) error {
 	project := d.Get("project").(string)
 	id := d.Id()
 
-	rules, _, err := client.Rules.List(org, project)
-	if err != nil {
-		d.SetId("")
-		return nil
+	rules, resp, err := client.Rules.List(org, project)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return err
 	}
 
 	var rule *sentry.Rule

--- a/sentry/resource_sentry_team.go
+++ b/sentry/resource_sentry_team.go
@@ -80,10 +80,9 @@ func resourceSentryTeamRead(d *schema.ResourceData, meta interface{}) error {
 	org := d.Get("organization").(string)
 	log.Printf("[DEBUG] Reading Sentry team %s (Organization: %s)", slug, org)
 
-	team, _, err := client.Teams.Get(org, slug)
-	if err != nil {
-		d.SetId("")
-		return nil
+	team, resp, err := client.Teams.Get(org, slug)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return err
 	}
 
 	d.SetId(team.Slug)


### PR DESCRIPTION
This new helper properly and uniformly handles Sentry API 404 errors
with respect to the Terraform SDK. Prior to this commit, in most places
an API error was always interpretted as a missing resource. Now, a 404
is considered a missing resource and other API errors are surfaced as
real errors. This will ensure that, for example, a user with a malformed
API token (bad permissions, etc) doesn't wipe out Terraform state.

Fixes the following Github issues:

- https://github.com/jianyuan/terraform-provider-sentry/issues/40
- https://github.com/jianyuan/terraform-provider-sentry/issues/57