### PR TITLE
Fix panic in case of unreachable sentry instance

### DIFF
--- a/sentry/helpers.go
+++ b/sentry/helpers.go
@@ -23,7 +23,7 @@ func Int(v int) *int {
 // `false`, `err` => encountered an unexpected error
 func checkClientGet(resp *http.Response, err error, d *schema.ResourceData) (bool, error) {
 	if err != nil {
-		if resp.StatusCode == http.StatusNotFound {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
 			return false, nil
 		}


### PR DESCRIPTION
In that case, there's no response and the checkClientGet method panics
It should print out the error instead

## Example before the fix:
![image](https://user-images.githubusercontent.com/29210090/89550926-447a6080-d7d8-11ea-99e3-08c269addf89.png)

### Exception:
```
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xd9e1e4][0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5:[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: goroutine 25 [running]:[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: github.com/jianyuan/terraform-provider-sentry/sentry.checkClientGet(...)[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/dev/terraform-provider-sentry/sentry/helpers.go:26[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: github.com/jianyuan/terraform-provider-sentry/sentry.resourceSentryTeamRead(0xc00012b110, 0xe091e0, 0xc0005f81c0, 0xc00012b110, 0x0)[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/dev/terraform-provider-sentry/sentry/resource_sentry_team.go:84 +0x1e4[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc0000b6a80, 0xc000109c70, 0xe091e0, 0xc0005f81c0, 0xc00017e000, 0xc000109c70, 0x0)[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/resource.go:455 +0x119[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc0000b04d8, 0x12747c0, 0xc000609b90, 0xc000109a90, 0xc0000b04d8, 0xc000609b90, 0xc000343b78)[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/helper/plugin/grpc_provider.go:525 +0x3d8[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler(0xfaccc0, 0xc0000b04d8, 0x12747c0, 0xc000609b90, 0xc0000ca840, 0x0, 0x12747c0, 0xc000609b90, 0xc000464870, 0x8a)[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/tfplugin5/tfplugin5.pb.go:3153 +0x217[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000290d80, 0x127eee0, 0xc00008a600, 0xc000192700, 0xc000282270, 0x197e2d0, 0x0, 0x0, 0x0)[0m
2020-08-06T15:16:17.348Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:1024 +0x501[0m
2020-08-06T15:16:17.349Z debug plugin.terraform-provider-sentry_v0.5.5: google.golang.org/grpc.(*Server).handleStream(0xc000290d80, 0x127eee0, 0xc00008a600, 0xc000192700, 0x0)[0m
2020-08-06T15:16:17.349Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:1313 +0xd3d[0m
2020-08-06T15:16:17.349Z debug plugin.terraform-provider-sentry_v0.5.5: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc00029c150, 0xc000290d80, 0x127eee0, 0xc00008a600, 0xc000192700)[0m
2020-08-06T15:16:17.349Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:722 +0xa1[0m
2020-08-06T15:16:17.349Z debug plugin.terraform-provider-sentry_v0.5.5: created by google.golang.org/grpc.(*Server).serveStreams.func1[0m
2020-08-06T15:16:17.349Z debug plugin.terraform-provider-sentry_v0.5.5: 	/home/jian/.gvm/pkgsets/go1.14.3/global/pkg/mod/google.golang.org/grpc@v1.27.1/server.go:720 +0xa1[0m
2020-08-06T15:16:17.352Z debug plugin: plugin process exited: path=/usr/local/bin/terraform-provider-sentry_v0.5.5 pid=638 error="exit status 2"[0m
2020/08/06 15:16:17 error <root>: eval: *terraform.EvalRefresh, err: rpc error: code = Unavailable desc = transport is closing[0m
2020/08/06 15:16:17 error <root>: eval: *terraform.EvalSequence, err: rpc error: code = Unavailable desc = transport is closing[0m
2020-08-06T15:16:17.352Z warning plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"[0m
2020-08-06T15:16:17.366Z debug plugin: plugin exited[0m
2020-08-06T15:16:17.367Z warning plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"[0m
2020-08-06T15:16:17.367Z warning plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"[0m
2020-08-06T15:16:17.367Z warning plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"[0m
```

## Example after the fix:
![image](https://user-images.githubusercontent.com/29210090/89550729-fe250180-d7d7-11ea-81af-eb192f9e1db8.png)
