### PR TITLE
Add project.remove_default_key option

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -26,6 +26,7 @@ The following arguments are supported:
 - `slug` - (Optional) The unique URL slug for this project. If this is not provided a slug is automatically generated based on the name.
 - `platform` - (Optional) The integration platform.
 - `resolve_age` - (Optional) Hours in which an issue is automatically resolve if not seen after this amount of time.
+- `remove_default_key` - (Optional) Whether or not to remove the default key Sentry creates for a new project. Note: this only works at resource creation time.
 
 ## Attribute Reference
 


### PR DESCRIPTION
This allows users to specify that the default client DSN created for a
new Sentry project should be removed. It allows for better and more
explicit control of Sentry resources using strictly Terraform.

Fixes https://github.com/jianyuan/terraform-provider-sentry/issues/71