### PR TITLE
add a default_key resource to manage the key created with a project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ website/node_modules
 *.test
 *.iml
 
+#binaries
+terraform-provider-sentry
+main
+
 website/vendor
 
 # Test exclusions

--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -27,6 +27,7 @@ func Provider() *schema.Provider {
 			"sentry_team":         resourceSentryTeam(),
 			"sentry_project":      resourceSentryProject(),
 			"sentry_key":          resourceSentryKey(),
+			"sentry_default_key":  resourceSentryDefaultKey(),
 			"sentry_plugin":       resourceSentryPlugin(),
 			"sentry_rule":         resourceSentryRule(),
 		},

--- a/sentry/resource_sentry_default_key.go
+++ b/sentry/resource_sentry_default_key.go
@@ -3,6 +3,7 @@ package sentry
 import (
 	"fmt"
 	"log"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
@@ -18,6 +19,7 @@ func resourceSentryDefaultKey() *schema.Resource {
 	dKey.Schema["name"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Computed:    true,
+		Optional:    true,
 		Description: "The name of the key",
 	}
 
@@ -35,9 +37,13 @@ func resourceSentryDefaultKeyCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	if len(keys) != 1 {
+	if len(keys) < 1 {
 		return fmt.Errorf("Default key not found on the project")
 	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].DateCreated.Before(keys[j].DateCreated)
+	})
 
 	id := keys[0].ID
 	params := &sentry.UpdateProjectKeyParams{

--- a/sentry/resource_sentry_default_key.go
+++ b/sentry/resource_sentry_default_key.go
@@ -1,0 +1,62 @@
+package sentry
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jianyuan/go-sentry/sentry"
+)
+
+func resourceSentryDefaultKey() *schema.Resource {
+	// reuse read and update operations
+	dKey := resourceSentryKey()
+	dKey.Create = resourceSentryDefaultKeyCreate
+	dKey.Delete = resourceAwsDefaultVpcDelete
+
+	// Key name is a computed resource for default key
+	dKey.Schema["name"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The name of the key",
+	}
+
+	return dKey
+}
+
+func resourceSentryDefaultKeyCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*sentry.Client)
+
+	org := d.Get("organization").(string)
+	project := d.Get("project").(string)
+
+	keys, resp, err := client.ProjectKeys.List(org, project)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return err
+	}
+
+	if len(keys) != 1 {
+		return fmt.Errorf("Default key not found on the project")
+	}
+
+	id := keys[0].ID
+	params := &sentry.UpdateProjectKeyParams{
+		Name: d.Get("name").(string),
+		RateLimit: &sentry.ProjectKeyRateLimit{
+			Window: d.Get("rate_limit_window").(int),
+			Count:  d.Get("rate_limit_count").(int),
+		},
+	}
+
+	if _, _, err = client.ProjectKeys.Update(org, project, id, params); err != nil {
+		return err
+	}
+
+	d.SetId(id)
+	return resourceSentryKeyRead(d, meta)
+}
+
+func resourceAwsDefaultVpcDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy Default Key. Terraform will remove this resource from the state file, however resources may remain.")
+	return nil
+}

--- a/sentry/resource_sentry_default_key_test.go
+++ b/sentry/resource_sentry_default_key_test.go
@@ -1,0 +1,151 @@
+package sentry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jianyuan/go-sentry/sentry"
+)
+
+func TestAccSentryDefaultKey_basic(t *testing.T) {
+	var key sentry.ProjectKey
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSentryDefaultKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryDefaultKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSentryDefaultKeyExists("sentry_default_key.test_key", &key),
+					resource.TestCheckResourceAttr("sentry_default_key.test_key", "name", "Test key"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "public"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "secret"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "dsn_secret"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "dsn_public"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "dsn_csp"),
+				),
+			},
+			{
+				Config: testAccSentryDefaultKeyUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSentryDefaultKeyExists("sentry_default_key.test_key", &key),
+					resource.TestCheckResourceAttr("sentry_default_key.test_key", "name", "Test key changed"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "public"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "secret"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "dsn_secret"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "dsn_public"),
+					resource.TestCheckResourceAttrSet("sentry_default_key.test_key", "dsn_csp"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSentryDefaultKey_RateLimit(t *testing.T) {
+	var key sentry.ProjectKey
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSentryDefaultKeyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryDefaultKeyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSentryDefaultKeyExists("sentry_default_key.test_key", &key),
+					resource.TestCheckResourceAttr("sentry_default_key.test_key", "rate_limit_window", "86400"),
+					resource.TestCheckResourceAttr("sentry_default_key.test_key", "rate_limit_count", "1000"),
+				),
+			},
+			{
+				Config: testAccSentryDefaultKeyUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSentryDefaultKeyExists("sentry_default_key.test_key", &key),
+					resource.TestCheckResourceAttr("sentry_default_key.test_key", "rate_limit_window", "100"),
+					resource.TestCheckResourceAttr("sentry_default_key.test_key", "rate_limit_count", "100"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSentryDefaultKeyDestroy(s *terraform.State) error {
+	return nil
+}
+
+func testAccCheckSentryDefaultKeyExists(n string, projectKey *sentry.ProjectKey) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No key ID is set")
+		}
+
+		client := testAccProvider.Meta().(*sentry.Client)
+		keys, _, err := client.ProjectKeys.List(
+			rs.Primary.Attributes["organization"],
+			rs.Primary.Attributes["project"],
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, key := range keys {
+			if key.ID == rs.Primary.ID {
+				*projectKey = key
+				break
+			}
+		}
+		return nil
+	}
+}
+
+var testAccSentryDefaultKeyConfig = fmt.Sprintf(`
+	resource "sentry_team" "test_team" {
+		organization = "%[1]s"
+		name = "Test team"
+	}
+
+	resource "sentry_project" "test_project" {
+		organization = "%[1]s"
+		team = "${sentry_team.test_team.id}"
+		name = "Test project"
+	}
+
+	resource "sentry_default_key" "test_key" {
+		organization = "%[1]s"
+		project = "${sentry_project.test_project.id}"
+		name = "Test key"
+		rate_limit_window = 86400
+		rate_limit_count = 1000
+	}
+`, testOrganization)
+
+var testAccSentryDefaultKeyUpdateConfig = fmt.Sprintf(`
+	resource "sentry_team" "test_team" {
+		organization = "%[1]s"
+		name = "Test team"
+	}
+
+	resource "sentry_project" "test_project" {
+		organization = "%[1]s"
+		team = "${sentry_team.test_team.id}"
+		name = "Test project"
+	}
+
+	resource "sentry_default_key" "test_key" {
+		organization = "%[1]s"
+		project = "${sentry_project.test_project.id}"
+		name = "Test key changed"
+		rate_limit_window = 100
+		rate_limit_count = 100
+	}
+`, testOrganization)

--- a/sentry/resource_sentry_project_rule.go
+++ b/sentry/resource_sentry_project_rule.go
@@ -182,11 +182,29 @@ func resourceSentryRuleRead(d *schema.ResourceData, meta interface{}) error {
 	// workaround for
 	// https://github.com/hashicorp/terraform-plugin-sdk/issues/62
 	// as the data sent by Sentry is integer
-	for _, f := range rule.Filters {
+	for _, f := range rule.Actions {
 		for k, v := range f {
 			switch vv := v.(type) {
 			case float64:
 				// unparseable so forcing this to be int
+				f[k] = fmt.Sprintf("%.0f", vv)
+			}
+		}
+	}
+
+	for _, f := range rule.Conditions {
+		for k, v := range f {
+			switch vv := v.(type) {
+			case float64:
+				f[k] = fmt.Sprintf("%.0f", vv)
+			}
+		}
+	}
+
+	for _, f := range rule.Filters {
+		for k, v := range f {
+			switch vv := v.(type) {
+			case float64:
 				f[k] = fmt.Sprintf("%.0f", vv)
 			}
 		}


### PR DESCRIPTION
- Create a sentry_default_key resource to manage the key created together with a project, without going trough importing steps. Modeled after [resource_aws_default_subnet](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_default_subnet.go). This is especially helpful when creating a project with rate limits in place for DSN keys.

- sentry_default_key resource doesn't allow deletion to prevent unmanageable state drifts. 

- Also adds some checks for the float values in conditions/filters similar to actions in the rules.