### PR TITLE
Enable to set digests_min_delay & digests_max_delay

### DIFF
--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -76,12 +76,16 @@ func resourceSentryProject() *schema.Resource {
 				Computed: true,
 			},
 			"digests_min_delay": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The minimum amount of time (in seconds) to wait between scheduling digests for delivery after the initial scheduling.",
+				Optional:    true,
 			},
 			"digests_max_delay": {
-				Type:     schema.TypeInt,
-				Computed: true,
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The maximum amount of time (in seconds) to wait between scheduling digests for delivery.",
+				Optional:    true,
 			},
 			"resolve_age": {
 				Type:        schema.TypeInt,


### PR DESCRIPTION
Hi @jianyuan, thank you for the useful plugin.

This PR enables to set `digests_min_delay` & `digests_max_delay` options for `sentry_project` resource. The source code of the plugin indicates that these options are already available, but since `Optional: true` was not specified in the Schema definition, the error `Computed attribute cannot be set` occurred. In this PR, I've defined a description in addition.