### PR TITLE
Support sourcing auth token from env var SENTRY_AUTH_TOKEN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,6 @@ jobs:
         timeout-minutes: 10
         env:
           SENTRY_TEST_ORGANIZATION: ${{ secrets.SENTRY_TEST_ORGANIZATION }}
-          SENTRY_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           make testacc

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ In order to run the full suite of acceptance tests, run `make testacc`.
 Make sure to set the following environment variables beforehand:
 
 - `SENTRY_TEST_ORGANIZATION`
-- `SENTRY_TOKEN`
+- `SENTRY_AUTH_TOKEN`
 
-*Note:* Acceptance tests create real resources, and often cost money to run.
+_Note:_ Acceptance tests create real resources, and often cost money to run.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Terraform provider for [Sentry](https://sentry.io).
 ```hcl
 # Configure the Sentry Provider
 provider "sentry" {
-  token = var.sentry_token
+  token    = var.sentry_auth_token
   base_url = var.sentry_base_url
 }
 ```
@@ -16,5 +16,5 @@ provider "sentry" {
 
 The following arguments are supported:
 
-- `token` - (Required) This is the Sentry authentication token. The value can be sourced from the `SENTRY_TOKEN` environment variable.
+- `token` - (Required) This is the Sentry authentication token. The value can be sourced from the `SENTRY_AUTH_TOKEN` environment variable.
 - `base_url` - (Optional) This is the target Sentry base API endpoint. The default value is `https://sentry.io/api/`. The value must be provided when working with Sentry On-Premise. The value can be sourced from the `SENTRY_BASE_URL` environment variable.

--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -11,7 +11,7 @@ func Provider() *schema.Provider {
 			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SENTRY_TOKEN", nil),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SENTRY_AUTH_TOKEN", "SENTRY_TOKEN"}, nil),
 				Description: "The authentication token used to connect to Sentry",
 			},
 			"base_url": {

--- a/sentry/provider_test.go
+++ b/sentry/provider_test.go
@@ -26,8 +26,8 @@ func TestProvider(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("SENTRY_TOKEN"); v == "" {
-		t.Fatal("SENTRY_TOKEN must be set for acceptance tests")
+	if v := os.Getenv("SENTRY_AUTH_TOKEN"); v == "" {
+		t.Fatal("SENTRY_AUTH_TOKEN must be set for acceptance tests")
 	}
 	if v := os.Getenv("SENTRY_TEST_ORGANIZATION"); v == "" {
 		t.Fatal("SENTRY_TEST_ORGANIZATION must be set for acceptance tests")


### PR DESCRIPTION
Support sourcing Sentry auth token from the following environment variables:

1. `SENTRY_AUTH_TOKEN` ([Matches upstream](https://docs.sentry.io/product/cli/configuration/#to-authenticate-manually))
1. `SENTRY_TOKEN` (For backwards compatibility)

Addresses #104.