### PR TITLE
add team to project if it has changed

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Build Tags
+on:
+  push:
+    tags:
+      - "*"
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12
+        id: go
+
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Download dependencies
+        run:  go mod download
+      - name: Build tag
+        uses: goreleaser/goreleaser-action@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.17
 
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1
-	github.com/jianyuan/go-sentry v1.2.1-0.20201022193837-4bc7bd117d9d
+	github.com/jianyuan/go-sentry v1.2.1-0.20220226053639-5107a7c89534
 	github.com/mitchellh/mapstructure v1.4.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dghubble/sling v1.1.0/go.mod h1:ZcPRuLm0qrcULW2gOrjXrAWgf76sahqSyxXyVOvkunE=
+github.com/dghubble/sling v1.3.0/go.mod h1:XXShWaBWKzNLhu2OxikSNFrlsvowtz4kyRuXUG7oQKY=
 github.com/dghubble/sling v1.4.0 h1:/n8MRosVTthvMbwlNZgLx579OGVjUOy3GNEv5BIqAWY=
 github.com/dghubble/sling v1.4.0/go.mod h1:0r40aNsU9EdDUVBNhfCstAtFgutjgJGYbO1oNzkMoM8=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
@@ -264,8 +265,12 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
+github.com/jianyuan/go-sentry v1.2.0 h1:J+td84GIYoZovZYV+0B+9YuAJ2dR4SMAsky3kXZU580=
+github.com/jianyuan/go-sentry v1.2.0/go.mod h1:IlgHIblLdlWCnqpIxFV4bnLb4fgg9xFfDd41p6kRc/Y=
 github.com/jianyuan/go-sentry v1.2.1-0.20201022193837-4bc7bd117d9d h1:sirTZr2Nr82goZBa3BZ0Tl5KfscFpb3OpndtoEs+k14=
 github.com/jianyuan/go-sentry v1.2.1-0.20201022193837-4bc7bd117d9d/go.mod h1:mOAkyH01bwLPuGwzORThkp5W2I8CZvyNXXnz1gHuT3s=
+github.com/jianyuan/go-sentry v1.2.1-0.20220226053639-5107a7c89534 h1:W50QmCQ5NrVC+IoZrAw2PjAFiBhUmMAyCn96A0buIvw=
+github.com/jianyuan/go-sentry v1.2.1-0.20220226053639-5107a7c89534/go.mod h1:LZt9pgCnEWnqk0c8S4w2LlIIJzAe8Hr1GXZfZnsR1O4=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -356,6 +361,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -192,7 +192,7 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		oldTeam, team := d.GetChange("team")
 
 		tflog.Debug(ctx, "Adding updated team to Sentry project", slug, "org", org, "team", team, "projectSlug")
-		_, err := client.Projects.AddTeam(org, params.Slug, team.(string))
+		_, _, err := client.Projects.AddTeam(org, params.Slug, team.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -187,6 +187,22 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	if d.HasChange("team") {
+		oldTeam, team := d.GetChange("team")
+
+		tflog.Debug(ctx, "Adding team to Sentry project", slug, "org", org, "team", team, "projectSlug")
+		_, err := client.Projects.AddTeam(org, params.Slug, team.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		_, err = client.Projects.RemoveTeam(org, params.Slug, oldTeam.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		tflog.Debug(ctx, "Added team to Sentry project", slug, "org", org, "team", team, "projectSlug")
+	}
 	tflog.Debug(ctx, "Updated Sentry project", "projectSlug", proj.Slug, "projectID", proj.ID, "org", org)
 
 	d.SetId(proj.Slug)

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -191,17 +191,19 @@ func resourceSentryProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("team") {
 		oldTeam, team := d.GetChange("team")
 
-		tflog.Debug(ctx, "Adding team to Sentry project", slug, "org", org, "team", team, "projectSlug")
+		tflog.Debug(ctx, "Adding updated team to Sentry project", slug, "org", org, "team", team, "projectSlug")
 		_, err := client.Projects.AddTeam(org, params.Slug, team.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		tflog.Debug(ctx, "Added updated team to Sentry project", "projectSlug", slug, "org", org, "team", team)
 
+		tflog.Debug(ctx, "Removing old team from Sentry project", "projectSlug", slug, "org", org, "oldTeam", oldTeam)
 		_, err = client.Projects.RemoveTeam(org, params.Slug, oldTeam.(string))
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		tflog.Debug(ctx, "Added team to Sentry project", slug, "org", org, "team", team, "projectSlug")
+		tflog.Debug(ctx, "Removed old team to Sentry project", slug, "org", org, "team", team, "projectSlug")
 	}
 	tflog.Debug(ctx, "Updated Sentry project", "projectSlug", proj.Slug, "projectID", proj.ID, "org", org)
 


### PR DESCRIPTION
This updates the team of a project if it changes. Since the API only supports add and delete we must add the new team to the project while deleting the older one