### PR TITLE
datasources: add sentry_team

### DIFF
--- a/docs/data-sources/team.md
+++ b/docs/data-sources/team.md
@@ -1,0 +1,28 @@
+# sentry_team Data Source
+
+Sentry Team data source.
+
+## Example Usage
+
+```hcl
+# Retrieve the team
+data "sentry_team" "app_team" {
+  organization = "my-organization-slug"
+  slug         = "some-team"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `slug` - (required) The unique URL slug for this team.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `id` - The internal ID for this team.
+- `name` - The human readable name for this team.
+- `slug` - The unique URL slug for this team.
+- `team_id` - The internal ID for this team.

--- a/sentry/data_source_sentry_team.go
+++ b/sentry/data_source_sentry_team.go
@@ -1,0 +1,60 @@
+package sentry
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jianyuan/go-sentry/sentry"
+)
+
+func dataSourceSentryTeam() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceTeamRead,
+
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"slug": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"team_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceTeamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*sentry.Client)
+
+	org := d.Get("organization").(string)
+	slug := d.Get("slug").(string)
+
+	tflog.Debug(ctx, "Reading Sentry Team", "org", org, "teamSlug", slug)
+	team, _, err := client.Teams.Get(org, slug)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	tflog.Debug(ctx, "Read Sentry Team", "teamName", team.Name, "teamSlug", team.Slug, "teamID", team.ID)
+
+	d.SetId(team.Slug)
+	d.Set("slug", team.Slug)
+	d.Set("name", team.Name)
+	d.Set("team_id", team.ID)
+
+	return nil
+}

--- a/sentry/data_source_sentry_team_test.go
+++ b/sentry/data_source_sentry_team_test.go
@@ -1,0 +1,39 @@
+package sentry
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccSentryTeamDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryTeamataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.sentry_team.test", "name", "Test team"),
+					resource.TestCheckResourceAttr("data.sentry_team.test", "slug", "test-team"),
+					resource.TestCheckResourceAttrSet("data.sentry_team.test", "team_id"),
+				),
+			},
+		},
+	})
+}
+
+// Testing first parameter
+var testAccSentryTeamataSourceConfig = fmt.Sprintf(`
+resource "sentry_team" "test_team" {
+  organization = "%s"
+  name = "Test team"
+	slug = "test-team"
+}
+
+data "sentry_team" "test_key" {
+  organization = "%s"
+	slug = "test-team"
+}
+`, testOrganization, testOrganization)

--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -38,6 +38,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"sentry_key":          dataSourceSentryKey(),
 			"sentry_organization": dataSourceSentryOrganization(),
+			"sentry_team":         dataSourceSentryTeam(),
 		},
 
 		ConfigureContextFunc: providerContextConfigure,


### PR DESCRIPTION
Adds a `sentry_team` datasource, for when you need to look up the internal team id (e.g. for a `sentry_rule.filter.targetIdentifier`)

The ID is exported both as `id` and as `team_id` to match the `sentry_team` resource.

This has been tested locally, and is now in active use!