### PR TITLE
Sentry Organization Member Resource

### DIFF
--- a/docs/resources/organization_member.md
+++ b/docs/resources/organization_member.md
@@ -1,0 +1,41 @@
+# sentry_organization_member Resource
+
+Sentry Organization Member resource.
+
+## Example Usage
+
+```hcl
+# Create an organization member
+resource "sentry_organization_member" "john_doe" {
+  email = "test@example.com"
+  role  = "member"
+  teams = ["my-team"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `email` - (Required) The email address of the user you want to invite.
+- `role` - (Required) The role of the user you want to invite. Must be one of the following: `member`, `manager`, `billing`, `admin` or `owner`. 
+- `teams` - (Optional) The list of slugs for each team you want to add the member to.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+- `member_id` - The ID of the created organization member.
+- `teams` - The list of teams that the member is a part of.
+- `role` - The role that the user has.
+- `email` - The email address of the organization member.
+- `pending` - The boolean acceptance status of the membership invite. e.g. True means the invite has not been accepted.
+- `expired` - A boolean that tells you whether the membership invite has expired.
+
+## Import
+
+This resource can be imported using an ID made up of the organization slug and member ID.
+
+```bash
+$ terraform import sentry_organization.default org-slug/member-id
+```

--- a/sentry/import_sentry_organization_member.go
+++ b/sentry/import_sentry_organization_member.go
@@ -1,0 +1,26 @@
+package sentry
+
+import (
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strings"
+)
+
+func resourceOrganizationMemberImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	addrID := d.Id()
+
+	tflog.Debug(ctx, "Importing Sentry organization member", map[string]interface{}{
+		"addrId": addrID,
+	})
+
+	parts := strings.Split(addrID, "/")
+
+	if len(parts) != 2 {
+		return nil, errors.New("organization member import requires an ADDR ID of the following schema org-slug/member-id")
+	}
+
+	d.Set("organization", parts[0])
+	d.SetId(parts[1])
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/sentry/resource_sentry_organization_member.go
+++ b/sentry/resource_sentry_organization_member.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jianyuan/go-sentry/sentry"
+	"sort"
 )
 
 func resourceSentryOrganizationMember() *schema.Resource {
@@ -123,6 +124,8 @@ func resourceSentryOrganizationMemberRead(ctx context.Context, d *schema.Resourc
 		"teams": member.Teams,
 		"org":   org,
 	})
+
+	sort.Strings(member.Teams)
 
 	d.SetId(member.ID)
 	d.Set("member_id", member.ID)

--- a/sentry/resource_sentry_organization_member.go
+++ b/sentry/resource_sentry_organization_member.go
@@ -1,0 +1,200 @@
+package sentry
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jianyuan/go-sentry/sentry"
+)
+
+func resourceSentryOrganizationMember() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSentryOrganizationMemberCreate,
+		ReadContext:   resourceSentryOrganizationMemberRead,
+		UpdateContext: resourceSentryOrganizationMemberUpdate,
+		DeleteContext: resourceSentryOrganizationMemberDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceOrganizationMemberImporter,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"organization": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The slug of the organization the team should be created for",
+			},
+			"email": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The email of the organization member",
+			},
+			"role": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "This is the role of the organization member",
+			},
+			"teams": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The slugs of the teams to add the member too",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"member_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique member identifier",
+			},
+			"pending": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The invite is pending",
+			},
+			"expired": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "The invite is expired",
+			},
+		},
+	}
+}
+
+func resourceSentryOrganizationMemberCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*sentry.Client)
+
+	org := d.Get("organization").(string)
+	params := &sentry.CreateOrganizationMemberParams{
+		Email: d.Get("email").(string),
+		Role:  d.Get("role").(string),
+	}
+
+	if v, ok := d.GetOk("teams"); ok {
+		teamsInput := v.([]interface{})
+		teams := make([]string, len(teamsInput))
+		for i, team := range teamsInput {
+			teams[i] = fmt.Sprint(team)
+		}
+		if len(teams) > 0 {
+			params.Teams = teams
+		}
+	}
+
+	tflog.Debug(ctx, "Inviting Sentry organization member", map[string]interface{}{
+		"email": params.Email,
+		"org":   org,
+		"teams": params.Teams,
+	})
+	member, _, err := client.OrganizationMembers.Create(org, params)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	tflog.Debug(ctx, "Invited Sentry organization member", map[string]interface{}{
+		"email": params.Email,
+		"org":   org,
+		"teams": params.Teams,
+	})
+
+	d.Set("organization", org)
+	d.SetId(member.ID)
+	return resourceSentryOrganizationMemberRead(ctx, d, meta)
+}
+
+func resourceSentryOrganizationMemberRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*sentry.Client)
+
+	memberId := d.Id()
+	org := d.Get("organization").(string)
+
+	tflog.Debug(ctx, "Reading Sentry organization member", map[string]interface{}{
+		"memberId": memberId,
+		"org":      org,
+	})
+	member, resp, err := client.OrganizationMembers.Get(org, memberId)
+	if found, err := checkClientGet(resp, err, d); !found {
+		return diag.FromErr(err)
+	}
+	tflog.Debug(ctx, "Read Sentry organization member", map[string]interface{}{
+		"email": member.Email,
+		"role":  member.Role,
+		"id":    member.ID,
+		"teams": member.Teams,
+		"org":   org,
+	})
+
+	d.SetId(member.ID)
+	d.Set("member_id", member.ID)
+	d.Set("email", member.Email)
+	d.Set("role", member.Role)
+	d.Set("teams", member.Teams)
+	d.Set("expired", member.Expired)
+	d.Set("pending", member.Pending)
+	return nil
+}
+
+func resourceSentryOrganizationMemberUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*sentry.Client)
+
+	memberId := d.Id()
+	org := d.Get("organization").(string)
+	params := &sentry.UpdateOrganizationMemberParams{
+		Role: d.Get("role").(string),
+	}
+
+	if v, ok := d.GetOk("teams"); ok {
+		teamsInput := v.([]interface{})
+		teams := make([]string, len(teamsInput))
+		for i, team := range teamsInput {
+			teams[i] = fmt.Sprint(team)
+		}
+		if len(teams) > 0 {
+			params.Teams = teams
+		}
+	}
+
+	tflog.Debug(ctx, "Updating organization member", map[string]interface{}{
+		"email": d.Get("email"),
+		"role":  params.Role,
+		"id":    memberId,
+		"teams": params.Teams,
+		"org":   org,
+	})
+
+	member, _, err := client.OrganizationMembers.Update(org, memberId, params)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	tflog.Debug(ctx, "Updated Sentry organization member", map[string]interface{}{
+		"email": d.Get("email"),
+		"role":  params.Role,
+		"id":    memberId,
+		"teams": params.Teams,
+		"org":   org,
+	})
+
+	d.SetId(member.ID)
+	return resourceSentryOrganizationMemberRead(ctx, d, meta)
+}
+
+func resourceSentryOrganizationMemberDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*sentry.Client)
+
+	memberId := d.Id()
+	org := d.Get("organization").(string)
+
+	tflog.Debug(ctx, "Deleting Sentry organization member", map[string]interface{}{
+		"memberId": memberId,
+		"email":    d.Get("email"),
+		"org":      org,
+	})
+	_, err := client.OrganizationMembers.Delete(org, memberId)
+	tflog.Debug(ctx, "Deleted Sentry organization member", map[string]interface{}{
+		"memberId": memberId,
+		"email":    d.Get("email"),
+		"org":      org,
+	})
+
+	return diag.FromErr(err)
+}

--- a/sentry/resource_sentry_organization_member_test.go
+++ b/sentry/resource_sentry_organization_member_test.go
@@ -1,0 +1,133 @@
+package sentry
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jianyuan/go-sentry/sentry"
+)
+
+func TestAccSentryOrganizationMember_basic(t *testing.T) {
+	var member sentry.OrganizationMember
+
+	testAccSentrySentryOrganizationMemberUpdateConfig := fmt.Sprintf(`
+    resource "sentry_organization_member" "john_doe" {
+      organization = "%s"
+      email = "test2@example.com"
+      role = "manager"
+    }
+	`, testOrganization)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSentryOrganizationMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSentryOrganizationMemberConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSentryOrganizationMemberExists("sentry_organization_member.john_doe", &member),
+					testAccCheckSentryOrganizationMemberAttributes(&member, &testAccSentryOrganizationMemberExpectedAttributes{
+						Email: "test2@example.com",
+						Role:  sentry.RoleMember,
+					}),
+				),
+			},
+			{
+				Config: testAccSentrySentryOrganizationMemberUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSentryOrganizationMemberExists("sentry_organization_member.john_doe", &member),
+					testAccCheckSentryOrganizationMemberAttributes(&member, &testAccSentryOrganizationMemberExpectedAttributes{
+						Email: "test2@example.com",
+						Role:  sentry.RoleManager,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSentryOrganizationMemberDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*sentry.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sentry_organization_member" {
+			continue
+		}
+
+		member, resp, err := client.OrganizationMembers.Get(
+			rs.Primary.Attributes["organization"],
+			rs.Primary.ID,
+		)
+		if err == nil {
+			if member != nil {
+				return errors.New("organization member still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccCheckSentryOrganizationMemberExists(n string, member *sentry.OrganizationMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("no member ID is set")
+		}
+
+		client := testAccProvider.Meta().(*sentry.Client)
+		sentryOrganizationMember, _, err := client.OrganizationMembers.Get(
+			rs.Primary.Attributes["organization"],
+			rs.Primary.ID,
+		)
+
+		if err != nil {
+			return err
+		}
+		*member = *sentryOrganizationMember
+		return nil
+	}
+}
+
+type testAccSentryOrganizationMemberExpectedAttributes struct {
+	Email string
+	Role  string
+	Teams []string
+}
+
+func testAccCheckSentryOrganizationMemberAttributes(member *sentry.OrganizationMember, want *testAccSentryOrganizationMemberExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if member.Email != want.Email {
+			return fmt.Errorf("got email %q; want %q", member.Email, want.Email)
+		}
+
+		if member.Role != want.Role {
+			return fmt.Errorf("got role %q; want %q", member.Role, want.Role)
+		}
+
+		if len(member.Teams) != len(want.Teams) {
+			return fmt.Errorf("got total teams %d; want %d", len(member.Teams), len(want.Teams))
+		}
+
+		return nil
+	}
+}
+
+var testAccSentryOrganizationMemberConfig = fmt.Sprintf(`
+  resource "sentry_organization_member" "john_doe" {
+    organization = "%s"
+    email = "test2@example.com"
+	role = "member"
+  }
+`, testOrganization)


### PR DESCRIPTION
Hello 👋 ,
I've created a `sentry_organization_member` resource. We've implemented this using my own fork at work and we're pretty happy with it. I wanted to share it with you as well.

Here's an example of how it works. Any feedback is appreciated 😄 

```hcl
# Create an organization member
resource "sentry_organization_member" "john_doe" {
  email = "test@example.com"
  role  = "member"
  teams = ["my-team"]
}
```