### PR TITLE
Added rate limit config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,5 +28,5 @@ provider "sentry" {
 
 - `base_url` (String) The target Sentry Base API URL in the format `https://[hostname]/api/`. The default value is `https://sentry.io/api/`. The value must be provided when working with Sentry On-Premise. The value can be sourced from the `SENTRY_BASE_URL` environment variable.
 - `token` (String, Sensitive) The authentication token used to connect to Sentry. The value can be sourced from the `SENTRY_AUTH_TOKEN` environment variable.
-
+- `rate_limit_per_second` (Int) "The maximum rate that requests will be sent to Sentry. The default value is 40 as is Sentry's internal Rate limit. It can be set lower to avoid accidentally hitting the rate limit. The value can be sourced from the `SENTRY_RATE_LIMIT` environment variable.
 

--- a/sentry/config.go
+++ b/sentry/config.go
@@ -16,6 +16,8 @@ import (
 type Config struct {
 	Token   string
 	BaseURL string
+
+	RateLimitPerSecond int
 }
 
 // Client to connect to Sentry.
@@ -26,7 +28,7 @@ func (c *Config) Client(ctx context.Context) (interface{}, diag.Diagnostics) {
 	rateLimitHTTPClient := &http.Client{
 		Transport: &transport{
 			// 40 requests every second.
-			limiter: rate.NewLimiter(40, 1),
+			limiter: rate.NewLimiter(rate.Limit(c.RateLimitPerSecond), 1),
 		},
 	}
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, rateLimitHTTPClient)

--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -27,6 +27,14 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SENTRY_BASE_URL", "https://sentry.io/api/"),
 			},
+			"rate_limit_per_second": {
+				Description: "The maximum rate that requests will be sent to Sentry. " +
+					"The default value is 40 as is Sentry's internal Rate limit. " +
+					"The value can be sourced from the `SENTRY_RATE_LIMIT` environment variable.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SENTRY_RATE_LIMIT", 40),
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -56,8 +64,9 @@ func Provider() *schema.Provider {
 
 func providerContextConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	config := Config{
-		Token:   d.Get("token").(string),
-		BaseURL: d.Get("base_url").(string),
+		Token:   			d.Get("token").(string),
+		BaseURL: 			d.Get("base_url").(string),
+		RateLimitPerSecond: d.Get("rate_limit_per_second").(int),
 	}
 	return config.Client(ctx)
 }


### PR DESCRIPTION
This is just a quick proposal to be able to work around Sentry's request rate limit sometimes triggered. See #148
In general I'd say exposing the config is good, but you could say that this bloats the schema too much.