### PR TITLE
Allow mapping many teams to one project (#33)

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -17,7 +17,7 @@ Sentry Project resource.
 resource "sentry_project" "default" {
   organization = "my-organization"
 
-  team = "my-team"
+  teams = ["my-team"]
   name = "Web App"
   slug = "web-app"
 
@@ -33,7 +33,8 @@ resource "sentry_project" "default" {
 
 - `name` (String) The name for the project.
 - `organization` (String) The slug of the organization the project belongs to.
-- `team` (String) The slug of the team to create the project for.
+- `teams` (List of String) The slug of the teams to create the project for (one of `team` or `teams` is required).
+- `team` (String, Deprecated) Use `teams` instead.
 
 ### Optional
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -17,9 +17,9 @@ Sentry Project resource.
 resource "sentry_project" "default" {
   organization = "my-organization"
 
-  teams = ["my-team"]
-  name = "Web App"
-  slug = "web-app"
+  teams = ["my-first-team", "my-second-team"]
+  name  = "Web App"
+  slug  = "web-app"
 
   platform    = "javascript"
   resolve_age = 720
@@ -33,8 +33,6 @@ resource "sentry_project" "default" {
 
 - `name` (String) The name for the project.
 - `organization` (String) The slug of the organization the project belongs to.
-- `teams` (List of String) The slug of the teams to create the project for (one of `team` or `teams` is required).
-- `team` (String, Deprecated) Use `teams` instead.
 
 ### Optional
 
@@ -43,6 +41,8 @@ resource "sentry_project" "default" {
 - `platform` (String) The optional platform for this project.
 - `resolve_age` (Number) Hours in which an issue is automatically resolve if not seen after this amount of time.
 - `slug` (String) The optional slug for this project.
+- `team` (String, Deprecated) The slug of the team to create the project for. One of 'team' or 'teams' must be set.
+- `teams` (Set of String) The slugs of the teams to create the project for. One of 'team' or 'teams' must be set.
 
 ### Read-Only
 

--- a/examples/resources/sentry_project/resource.tf
+++ b/examples/resources/sentry_project/resource.tf
@@ -2,9 +2,9 @@
 resource "sentry_project" "default" {
   organization = "my-organization"
 
-  team = "my-team"
-  name = "Web App"
-  slug = "web-app"
+  teams = ["my-first-team", "my-second-team"]
+  name  = "Web App"
+  slug  = "web-app"
 
   platform    = "javascript"
   resolve_age = 720


### PR DESCRIPTION
# Intent

To introduce a new attribute to the `project` resource called `teams` which allows us to map many teams to a single project. Previously, we could only attached a single team to a project via the `team` attribute.

Due to Sentry's[ asynchronous handling](https://docs.sentry.io/api/teams/delete-a-team/) of team changes, these changes were found to be difficult to test via acceptance testing. Only a couple basic tests were added. For an extensive run through, please see this [video](https://www.canva.com/design/DAFGFB6OBpA/LjwlWUysSIYacHNkt1qcAg/watch?utm_content=DAFGFB6OBpA&utm_campaign=designshare&utm_medium=link2&utm_source=sharebutton). (The API token in the video has been revoked since its recording :P)

# Example

```hcl
resource "sentry_team" "team1" {
  organization = "tajpereira"
  name         = "team1"
}

resource "sentry_team" "team2" {
  organization = "tajpereira"
  name         = "team2"
}

resource "sentry_project" "project1" {
  organization = sentry_team.team1.organization
  teams         = [sentry_team.team1.id, sentry_team.team2.id] // NEW CHANGES
  name         = "project1"
}

```

