### PR TITLE
Updated metric alert to include integration id for slack action

### DIFF
--- a/docs/data-sources/metric_alert.md
+++ b/docs/data-sources/metric_alert.md
@@ -42,6 +42,7 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
+          integration_id    = action.value.integration_id
         }
       }
 
@@ -100,3 +101,4 @@ Read-Only:
 - `type` (String)
 
 
+- `integration_id` (Number)

--- a/docs/index.md
+++ b/docs/index.md
@@ -293,6 +293,18 @@ resource "sentry_metric_alert" "main" {
   }
 
   trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = 99999
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
     alert_threshold = 100
     label           = "warning"
     threshold_type  = 0

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -35,6 +35,18 @@ resource "sentry_metric_alert" "main" {
     threshold_type  = 0
   }
 
+   trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = 99999
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
   trigger {
     alert_threshold = 100
     label           = "warning"

--- a/examples/data-sources/sentry_metric_alert/data-source.tf
+++ b/examples/data-sources/sentry_metric_alert/data-source.tf
@@ -27,6 +27,7 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
+          integration_id    = action.value.integration_id
         }
       }
 

--- a/examples/kitchen-sink/demo.tf
+++ b/examples/kitchen-sink/demo.tf
@@ -207,6 +207,18 @@ resource "sentry_metric_alert" "main" {
   }
 
   trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = 99999
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
     alert_threshold = 100
     label           = "warning"
     threshold_type  = 0

--- a/examples/resources/sentry_metric_alert/resource.tf
+++ b/examples/resources/sentry_metric_alert/resource.tf
@@ -21,6 +21,18 @@ resource "sentry_metric_alert" "main" {
   }
 
   trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = 99999
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
     alert_threshold = 100
     label           = "warning"
     threshold_type  = 0

--- a/sentry/data_source_sentry_metric_alert.go
+++ b/sentry/data_source_sentry_metric_alert.go
@@ -97,6 +97,10 @@ func dataSourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
 								},
 							},
 						},

--- a/sentry/data_source_sentry_metric_alert_test.go
+++ b/sentry/data_source_sentry_metric_alert_test.go
@@ -100,6 +100,19 @@ resource "sentry_metric_alert" "test" {
 		resolve_threshold = 100.0
 		threshold_type    = 0
 	}
+
+	trigger {
+		action {
+			type              = "slack"
+			target_type       = "specific"
+			target_identifier = "#slack-channel"
+			integration_id    = 99999
+		}
+			
+		alert_threshold = 300
+		label           = "critical"
+		threshold_type  = 0
+  }
 }
 
 data "sentry_metric_alert" "test" {
@@ -128,6 +141,7 @@ resource "sentry_metric_alert" "test_copy" {
 					type              = action.value.type
 					target_type       = action.value.target_type
 					target_identifier = action.value.target_identifier
+					integration_id    = action.value.integration_id
 				}
 			}
 

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -106,6 +106,11 @@ func resourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Computed: true,
+									},
 								},
 							},
 						},
@@ -318,6 +323,7 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 			Type:             sentry.String(actionMap["type"].(string)),
 			TargetType:       sentry.String(actionMap["target_type"].(string)),
 			TargetIdentifier: sentry.String(actionMap["target_identifier"].(string)),
+			IntegrationID:    sentry.Int(actionMap["integration_id"].(int)),
 		}
 		if v, ok := actionMap["id"].(string); ok {
 			if v != "" {

--- a/sentry/resource_sentry_metric_alert_test.go
+++ b/sentry/resource_sentry_metric_alert_test.go
@@ -141,6 +141,19 @@ resource "sentry_metric_alert" "test" {
 	}
 
 	trigger {
+		action {
+			type              = "slack"
+			target_type       = "specific"
+			target_identifier = "#slack-channel"
+			integration_id    = 99999
+		}
+			
+		alert_threshold = 300
+		label           = "critical"
+		threshold_type  = 0
+  	}
+
+	trigger {
 		alert_threshold   = 500
 		label             = "warning"
 		resolve_threshold = 100.0


### PR DESCRIPTION
Currently, it seems that it's not possible to use slack action for metric alerts.
If defining action like this
```
type               = "slack"
target_type        = "specific"
target_identifier  = "#chanel-name"
```
We get error > `{"integration":["Integration must be provided for slack"]}`

I am not great in go but tried to make a small proof of concept PR for what would need to be added to make it possibly work. Hopefully, you can fix and extend this to make slack actions also supported.