### PR TITLE
Add unit of measurement to `sentry_key`

### DIFF
--- a/docs/resources/key.md
+++ b/docs/resources/key.md
@@ -34,7 +34,7 @@ resource "sentry_key" "default" {
 ### Optional
 
 - `rate_limit_count` (Number) Number of events that can be reported within the rate limit window.
-- `rate_limit_window` (Number) Length of time that will be considered when checking the rate limit.
+- `rate_limit_window` (Number) Length of time in seconds that will be considered when checking the rate limit.
 
 ### Read-Only
 


### PR DESCRIPTION
Adds unit of measurement to `sentry_key`'s documentation as it's not
clear from the API or the provider documentation.

Resolves: https://github.com/jianyuan/terraform-provider-sentry/issues/100