### PR TITLE
Add Integration ID to Metric Alert

### DIFF
--- a/docs/data-sources/metric_alert.md
+++ b/docs/data-sources/metric_alert.md
@@ -42,6 +42,7 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
+          integration_id    = action.value.integration_id
         }
       }
 
@@ -95,6 +96,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `integration_id` (Number)
 - `target_identifier` (String)
 - `target_type` (String)
 - `type` (String)

--- a/docs/index.md
+++ b/docs/index.md
@@ -274,6 +274,12 @@ output "issue_alert_url" {
 # Metric alert
 #
 
+data "sentry_organization_integration" "slack" {
+  organization = "organization"
+  provider_key = "slack"
+  name         = "organization-slack"
+}
+
 resource "sentry_metric_alert" "main" {
   organization      = sentry_project.main.organization
   project           = sentry_project.main.id
@@ -290,6 +296,18 @@ resource "sentry_metric_alert" "main" {
       type              = "email"
       target_type       = "team"
       target_identifier = sentry_team.main.team_id
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300
     label           = "critical"

--- a/docs/index.md
+++ b/docs/index.md
@@ -277,7 +277,7 @@ output "issue_alert_url" {
 data "sentry_organization_integration" "slack" {
   organization = "organization"
   provider_key = "slack"
-  name         = "organization-slack"
+  name         = "Organization" // corresponds to Slack's name of your organisation
 }
 
 resource "sentry_metric_alert" "main" {

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -13,6 +13,12 @@ Sentry Metric Alert resource.
 ## Example Usage
 
 ```terraform
+data "sentry_organization_integration" "slack" {
+  organization = "organization"
+  provider_key = "slack"
+  name         = "organization-slack"
+}
+
 resource "sentry_metric_alert" "main" {
   organization      = sentry_project.main.organization
   project           = sentry_project.main.id
@@ -29,6 +35,18 @@ resource "sentry_metric_alert" "main" {
       type              = "email"
       target_type       = "team"
       target_identifier = sentry_team.main.team_id
+    }
+    alert_threshold = 300
+    label           = "critical"
+    threshold_type  = 0
+  }
+
+  trigger {
+    action {
+      type              = "slack"
+      target_type       = "specific"
+      target_identifier = "#slack-channel"
+      integration_id    = data.sentry_organization_integration.slack.internal_id
     }
     alert_threshold = 300
     label           = "critical"
@@ -95,6 +113,10 @@ Required:
 - `target_identifier` (String)
 - `target_type` (String)
 - `type` (String)
+
+Optional:
+
+- `integration_id` (Number)
 
 Read-Only:
 

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -46,7 +46,7 @@ resource "sentry_metric_alert" "main" {
       type              = "slack"
       target_type       = "specific"
       target_identifier = "#slack-channel"
-      integration_id    = data.sentry_organization_integration.slack.internal_id
+      integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300
     label           = "critical"

--- a/examples/data-sources/sentry_metric_alert/data-source.tf
+++ b/examples/data-sources/sentry_metric_alert/data-source.tf
@@ -27,6 +27,7 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
+          integration_id    = action.value.integration_id
         }
       }
 

--- a/sentry/data_source_sentry_metric_alert.go
+++ b/sentry/data_source_sentry_metric_alert.go
@@ -97,6 +97,10 @@ func dataSourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -367,9 +367,7 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["type"] = action.Type
 		actionMap["target_type"] = action.TargetType
 		actionMap["target_identifier"] = action.TargetIdentifier
-		if action.IntegrationID != nil {
-			actionMap["integration_id"] = action.IntegrationID
-		}
+		actionMap["integration_id"] = action.IntegrationID
 
 		actionList = append(actionList, actionMap)
 	}

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -328,7 +328,7 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 				action.ID = sentry.String(v)
 			}
 		}
-		if v, _ := actionMap["integration_id"].(int); v != 0 {
+		if v, ok := actionMap["integration_id"].(int); ok && v != 0 {
 			action.IntegrationID = sentry.Int(v)
 		}
 		actions = append(actions, action)

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -106,6 +106,10 @@ func resourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -324,6 +328,9 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 				action.ID = sentry.String(v)
 			}
 		}
+		if v, _ := actionMap["integration_id"].(int); v != 0 {
+			action.IntegrationID = sentry.Int(v)
+		}
 		actions = append(actions, action)
 	}
 	return actions
@@ -360,7 +367,12 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["type"] = action.Type
 		actionMap["target_type"] = action.TargetType
 		actionMap["target_identifier"] = action.TargetIdentifier
+		if action.IntegrationID != nil {
+			actionMap["integration_id"] = action.IntegrationID
+		}
+
 		actionList = append(actionList, actionMap)
 	}
+
 	return actionList
 }

--- a/sentry/resource_sentry_metric_alert_test.go
+++ b/sentry/resource_sentry_metric_alert_test.go
@@ -132,7 +132,7 @@ resource "sentry_metric_alert" "test" {
 			type              = "email"
 			target_type       = "team"
 			target_identifier = sentry_team.test.internal_id
-            integration_id    = 32
+			integration_id    = 32
 		}
 
 		alert_threshold   = 1000

--- a/sentry/resource_sentry_metric_alert_test.go
+++ b/sentry/resource_sentry_metric_alert_test.go
@@ -132,6 +132,7 @@ resource "sentry_metric_alert" "test" {
 			type              = "email"
 			target_type       = "team"
 			target_identifier = sentry_team.test.internal_id
+            integration_id    = 32
 		}
 
 		alert_threshold   = 1000


### PR DESCRIPTION
# Intent

Piggyback off [GirtsZemitis](https://github.com/GirtsZemitis)'s great starter (https://github.com/jianyuan/terraform-provider-sentry/pull/196) to add an integration ID to metric alerts. 

We need to add an `integration_id` field to the metric alert action in order to specify the Slack Integration (in order to send alerts to Slack).

This is seen in the below example:

```tf
data "sentry_organization_integration" "slack" {
  organization = "organization"
  provider_key = "slack"
  name         = "Organization" // corresponds to Slack's name of your organisation
}

resource "sentry_metric_alert" "main" {
  // ...
  trigger {
    action {
      type              = "slack"
      target_type       = "specific"
      target_identifier = "#slack-channel"
      integration_id    = data.sentry_organization_integration.slack.id // <---- New addition
    }
    // ...
  }

```
## Prereqs

Requires https://github.com/jianyuan/go-sentry/pull/66