### PR TITLE
fix: Add missing python-aiohttp

### DIFF
--- a/sentry/platform_categories.go
+++ b/sentry/platform_categories.go
@@ -93,6 +93,7 @@ var platformCategories = []string{
 	"php-monolog",
 	"php-symfony2",
 	"python",
+	"python-aiohttp",
 	"python-django",
 	"python-flask",
 	"python-fastapi",


### PR DESCRIPTION
When upgrading to a new version of the provider [v0.11.0](https://github.com/jianyuan/terraform-provider-sentry/releases/tag/v0.11.0), we found a problem that the configs does not pass verification, although everything works well on version 0.10.0

it seems that the problem is related to the [addition](https://github.com/jianyuan/terraform-provider-sentry/pull/241/) of project platform validation.

in our case, we use `python-aiohttp` and this type of platform is accepted by sentry when calling the API directly

```bash
> curl https://sentry.io/api/0/projects/.../ \
 -H 'Authorization: Bearer ***' \
 -X PUT \
 -H 'Content-Type: application/json' \
 -d '{"name":"...","platform":"python-aiohttp","slug":"..."}'

< HTTP/1.1 200 OK
```
