### PR TITLE
fix: Add missing apple to platformCategories

### DIFF
--- a/sentry/platform_categories.go
+++ b/sentry/platform_categories.go
@@ -49,6 +49,7 @@ var platformCategories = []string{
 
 	// Mobile
 	"android",
+	"apple",
 	"apple-ios",
 	"cordova",
 	"capacitor",


### PR DESCRIPTION
same problem as in this issue #255

we use the `apple` platform. unfortunately, it is not in the list of platforms, although the sentry API accepts this type

```bash
> curl https://sentry.io/api/0/projects/.../ \
 -H 'Authorization: Bearer ***' \
 -X PUT \
 -H 'Content-Type: application/json' \
 -d '{"name":"***","platform":"apple","slug":"***"}' \

< HTTP/1.1 200 OK
```
