### PR TITLE
Feat | Add input_channel_id on sentry_metric_alert

### DIFF
--- a/docs/data-sources/metric_alert.md
+++ b/docs/data-sources/metric_alert.md
@@ -43,6 +43,7 @@ resource "sentry_metric_alert" "copy" {
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
           integration_id    = action.value.integration_id
+          input_channel_id  = action.value.input_channel_id
         }
       }
 
@@ -97,6 +98,7 @@ Read-Only:
 Read-Only:
 
 - `id` (String)
+- `input_channel_id` (String)
 - `integration_id` (Number)
 - `target_identifier` (String)
 - `target_type` (String)

--- a/docs/data-sources/metric_alert.md
+++ b/docs/data-sources/metric_alert.md
@@ -42,8 +42,8 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
-          integration_id    = action.value.integration_id
           input_channel_id  = action.value.input_channel_id
+          integration_id    = action.value.integration_id
         }
       }
 

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -46,6 +46,7 @@ resource "sentry_metric_alert" "main" {
       type              = "slack"
       target_type       = "specific"
       target_identifier = "#slack-channel"
+      input_channel_id  = "C0XXXXXXXXX" #
       integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300
@@ -116,6 +117,7 @@ Required:
 
 Optional:
 
+- `input_channel_id` (String) Slack channel ID to avoid rate-limiting, see [here](https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error)
 - `integration_id` (Number)
 - `target_identifier` (String)
 

--- a/docs/resources/metric_alert.md
+++ b/docs/resources/metric_alert.md
@@ -46,7 +46,7 @@ resource "sentry_metric_alert" "main" {
       type              = "slack"
       target_type       = "specific"
       target_identifier = "#slack-channel"
-      input_channel_id  = "C0XXXXXXXXX" #
+      input_channel_id  = "C0XXXXXXXXX"
       integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300

--- a/examples/data-sources/sentry_metric_alert/data-source.tf
+++ b/examples/data-sources/sentry_metric_alert/data-source.tf
@@ -28,6 +28,7 @@ resource "sentry_metric_alert" "copy" {
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
           integration_id    = action.value.integration_id
+          input_channel_id  = action.value.input_channel_id
         }
       }
 

--- a/examples/data-sources/sentry_metric_alert/data-source.tf
+++ b/examples/data-sources/sentry_metric_alert/data-source.tf
@@ -27,8 +27,8 @@ resource "sentry_metric_alert" "copy" {
           type              = action.value.type
           target_type       = action.value.target_type
           target_identifier = action.value.target_identifier
-          integration_id    = action.value.integration_id
           input_channel_id  = action.value.input_channel_id
+          integration_id    = action.value.integration_id
         }
       }
 

--- a/examples/resources/sentry_metric_alert/resource.tf
+++ b/examples/resources/sentry_metric_alert/resource.tf
@@ -31,6 +31,7 @@ resource "sentry_metric_alert" "main" {
       type              = "slack"
       target_type       = "specific"
       target_identifier = "#slack-channel"
+      input_channel_id  = "C0XXXXXXXXX" #
       integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300

--- a/examples/resources/sentry_metric_alert/resource.tf
+++ b/examples/resources/sentry_metric_alert/resource.tf
@@ -31,7 +31,7 @@ resource "sentry_metric_alert" "main" {
       type              = "slack"
       target_type       = "specific"
       target_identifier = "#slack-channel"
-      input_channel_id  = "C0XXXXXXXXX" #
+      input_channel_id  = "C0XXXXXXXXX"
       integration_id    = data.sentry_organization_integration.slack.id
     }
     alert_threshold = 300

--- a/sentry/data_source_sentry_metric_alert.go
+++ b/sentry/data_source_sentry_metric_alert.go
@@ -109,6 +109,10 @@ func dataSourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeInt,
 										Computed: true,
 									},
+									"input_channel_id": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
 								},
 							},
 						},

--- a/sentry/data_source_sentry_metric_alert.go
+++ b/sentry/data_source_sentry_metric_alert.go
@@ -105,12 +105,12 @@ func dataSourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Computed: true,
 									},
-									"integration_id": {
-										Type:     schema.TypeInt,
-										Computed: true,
-									},
 									"input_channel_id": {
 										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"integration_id": {
+										Type:     schema.TypeInt,
 										Computed: true,
 									},
 								},

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -119,6 +119,11 @@ func resourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeInt,
 										Optional: true,
 									},
+									"input_channel_id": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: "Slack channel ID to avoid rate-limiting, see [here](https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error)",
+									},
 								},
 							},
 						},
@@ -356,6 +361,11 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 				action.IntegrationID = sentry.Int(v)
 			}
 		}
+		if v, ok := actionMap["input_channel_id"].(string); ok {
+			if v != "" {
+				action.InputChannelID = sentry.String(v)
+			}
+		}
 		actions = append(actions, action)
 	}
 	return actions
@@ -393,6 +403,7 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["target_type"] = action.TargetType
 		actionMap["target_identifier"] = action.TargetIdentifier
 		actionMap["integration_id"] = action.IntegrationID
+		actionMap["input_channel_id"] = action.InputChannelID
 
 		actionList = append(actionList, actionMap)
 	}

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -115,14 +115,14 @@ func resourceSentryMetricAlert() *schema.Resource {
 										Type:     schema.TypeString,
 										Optional: true,
 									},
-									"integration_id": {
-										Type:     schema.TypeInt,
-										Optional: true,
-									},
 									"input_channel_id": {
 										Type:        schema.TypeString,
 										Optional:    true,
 										Description: "Slack channel ID to avoid rate-limiting, see [here](https://docs.sentry.io/product/integrations/notification-incidents/slack/#rate-limiting-error)",
+									},
+									"integration_id": {
+										Type:     schema.TypeInt,
+										Optional: true,
 									},
 								},
 							},
@@ -356,14 +356,14 @@ func expandMetricAlertTriggerActions(actionList []interface{}) []*sentry.MetricA
 				action.TargetIdentifier = sentry.String(v)
 			}
 		}
-		if v, ok := actionMap["integration_id"].(int); ok {
-			if v != 0 {
-				action.IntegrationID = sentry.Int(v)
-			}
-		}
 		if v, ok := actionMap["input_channel_id"].(string); ok {
 			if v != "" {
 				action.InputChannelID = sentry.String(v)
+			}
+		}
+		if v, ok := actionMap["integration_id"].(int); ok {
+			if v != 0 {
+				action.IntegrationID = sentry.Int(v)
 			}
 		}
 		actions = append(actions, action)
@@ -402,8 +402,8 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["type"] = action.Type
 		actionMap["target_type"] = action.TargetType
 		actionMap["target_identifier"] = action.TargetIdentifier
-		actionMap["integration_id"] = action.IntegrationID
 		actionMap["input_channel_id"] = action.InputChannelID
+		actionMap["integration_id"] = action.IntegrationID
 
 		actionList = append(actionList, actionMap)
 	}


### PR DESCRIPTION
This closes the #281 

I have managed to create and set the `input_channel_id` using this version of the provider.

Please let me know what you think @jianyuan - thanks in advance for your time 🙏 
