### PR TITLE
feat: Support for `deafult_rules` in project resource

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -23,6 +23,8 @@ resource "sentry_project" "default" {
 
   platform    = "javascript"
   resolve_age = 720
+
+  default_rules = false
 }
 ```
 
@@ -36,6 +38,7 @@ resource "sentry_project" "default" {
 
 ### Optional
 
+- `default_rules` (Boolean) Whether to create a default issue alert
 - `digests_max_delay` (Number) The maximum amount of time (in seconds) to wait between scheduling digests for delivery.
 - `digests_min_delay` (Number) The minimum amount of time (in seconds) to wait between scheduling digests for delivery after the initial scheduling.
 - `platform` (String) The optional platform for this project.

--- a/examples/resources/sentry_project/resource.tf
+++ b/examples/resources/sentry_project/resource.tf
@@ -8,4 +8,6 @@ resource "sentry_project" "default" {
 
   platform    = "javascript"
   resolve_age = 720
+
+  default_rules = false
 }

--- a/sentry/resource_sentry_project.go
+++ b/sentry/resource_sentry_project.go
@@ -68,6 +68,11 @@ func resourceSentryProject() *schema.Resource {
 				Computed:         true,
 				ValidateDiagFunc: validatePlatform,
 			},
+			"default_rules": {
+				Description: "Whether to create a default issue alert",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
 			"internal_id": {
 				Description: "The internal ID for this project.",
 				Type:        schema.TypeString,
@@ -152,11 +157,17 @@ func resourceSentryProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		Slug: d.Get("slug").(string),
 	}
 
+	defaultRules, defaultRulesOk := d.GetOkExists("default_rules")
+	if defaultRulesOk {
+		params.DefaultRules = sentry.Bool(defaultRules.(bool))
+	}
+
 	tflog.Debug(ctx, "Creating Sentry project", map[string]interface{}{
 		"team":        team,
 		"teams":       teams,
 		"org":         org,
 		"initialTeam": initialTeam,
+		"defaultRules": params.DefaultRules,
 	})
 	proj, _, err := client.Projects.Create(ctx, org, initialTeam, params)
 	if err != nil {


### PR DESCRIPTION
### Why
This adds support for a `default_rules` input on the project resource and passes it through to the Create Project API - this leverages the change in https://github.com/jianyuan/go-sentry/pull/85.

### What
Using the [`GetOkExists()`](https://pkg.go.dev/github.com/hashicorp/terraform/helper/schema#ResourceData.GetOkExists) method to see if `default_rules` input was set on the resource, so that if the input is not provided then the param is not set on the request and the existing behaviour is maintained.

### How I tested
I tested all 3 states locally by creating projects with different values - unset, set `true` and set `false` and observed the expected behaviour (alert created, alert created, alert not created), but unfortunately, I don't believe this can easily be tested the existing tests as there's no way get back the ID/existence of the created alert. Open to any suggestions though.


As a sidenote - I'm not sure if https://github.com/jianyuan/go-sentry/ should get a new release? For now I've just used `go get github.com/jianyuan/go-sentry/v2@adc51b156720d66b78be6e4c229925fceb648d31` to point to the latest commit on the `main` branch

