### PR TITLE
fix: convert int64 to string for TypeString schema

### DIFF
--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -403,7 +404,7 @@ func flattenMetricAlertTriggerActions(actions []*sentry.MetricAlertTriggerAction
 		actionMap["target_type"] = action.TargetType
 		if action.TargetIdentifier != nil {
 			if action.TargetIdentifier.IsInt64 {
-				actionMap["target_identifier"] = action.TargetIdentifier.Int64Val
+				actionMap["target_identifier"] = strconv.FormatInt(action.TargetIdentifier.Int64Val, 10)
 			} else {
 				actionMap["target_identifier"] = action.TargetIdentifier.StringVal
 			}


### PR DESCRIPTION
Fix an error when metric alert resource uses target identifier as integer. As TargetIdentifier type is `TypeString`, Int64 value cannot be used.

Related:

- go-sentry: https://github.com/jianyuan/go-sentry/commit/87a326682444a0cd8e5065f260bbb56616d363dc 
- terraform-sentry-provider: https://github.com/jianyuan/terraform-provider-sentry/commit/a67bdb8955f4ced4c6d6d0b6ab6b85e132129a56#diff-783f37843eff34fb8e005a86d573f55e3666e64fe73cdb6ff8673e8ba81554c1

https://github.com/jianyuan/terraform-provider-sentry/issues/185