### PR TITLE
feat: Custom lossy JSON type

### DIFF
--- a/internal/provider/data_source_issue_alert_test.go
+++ b/internal/provider/data_source_issue_alert_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jianyuan/terraform-provider-sentry/internal/acctest"
+	"github.com/jianyuan/terraform-provider-sentry/internal/sentrytypes"
 )
 
 func TestAccIssueAlertDataSource(t *testing.T) {
@@ -33,8 +33,8 @@ func TestAccIssueAlertDataSource(t *testing.T) {
 				return fmt.Errorf("resource %s not found", b)
 			}
 
-			given := jsontypes.NewNormalizedValue(resA.Primary.Attributes[attr])
-			expected := jsontypes.NewNormalizedValue(resB.Primary.Attributes[attr])
+			expected := sentrytypes.NewLossyJsonValue(resA.Primary.Attributes[attr])
+			given := sentrytypes.NewLossyJsonValue(resB.Primary.Attributes[attr])
 			match, diags := expected.StringSemanticEquals(context.Background(), given)
 			if !match {
 				return fmt.Errorf("expected %s, got %s: %s", expected, given, diags)

--- a/internal/sentrytypes/lossy_json_type.go
+++ b/internal/sentrytypes/lossy_json_type.go
@@ -1,0 +1,111 @@
+package sentrytypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var _ basetypes.StringTypable = (*LossyJsonType)(nil)
+
+type LossyJsonType struct {
+	basetypes.StringType
+}
+
+func (t LossyJsonType) String() string {
+	return "sentrytypes.LossyJsonType"
+}
+
+func (t LossyJsonType) ValueType(_ context.Context) attr.Value {
+	return LossyJson{}
+}
+
+func (t LossyJsonType) Equal(o attr.Type) bool {
+	other, ok := o.(LossyJsonType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+func (t LossyJsonType) Validate(ctx context.Context, in tftypes.Value, path path.Path) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if in.Type() == nil {
+		return diags
+	}
+
+	if !in.Type().Is(tftypes.String) {
+		err := fmt.Errorf("expected String value, received %T with value: %v", in, in)
+		diags.AddAttributeError(
+			path,
+			"Lossy JSON Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+		return diags
+	}
+
+	if !in.IsKnown() || in.IsNull() {
+		return diags
+	}
+
+	var valueString string
+
+	if err := in.As(&valueString); err != nil {
+		diags.AddAttributeError(
+			path,
+			"Lossy JSON Type Validation Error",
+			"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. "+
+				"Please report the following to the provider developer:\n\n"+err.Error(),
+		)
+
+		return diags
+	}
+
+	if ok := json.Valid([]byte(valueString)); !ok {
+		diags.AddAttributeError(
+			path,
+			"Invalid JSON String Value",
+			"A string value was provided that is not valid JSON string format (RFC 7159).\n\n"+
+				"Given Value: "+valueString+"\n",
+		)
+
+		return diags
+	}
+
+	return diags
+}
+
+func (t LossyJsonType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return LossyJson{
+		StringValue: in,
+	}, nil
+}
+
+func (t LossyJsonType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}

--- a/internal/sentrytypes/lossy_json_type_test.go
+++ b/internal/sentrytypes/lossy_json_type_test.go
@@ -1,0 +1,139 @@
+package sentrytypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestLossyJsonTypeValidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in            tftypes.Value
+		expectedDiags diag.Diagnostics
+	}{
+		"empty-struct": {
+			in: tftypes.Value{},
+		},
+		"null": {
+			in: tftypes.NewValue(tftypes.String, nil),
+		},
+		"unknown": {
+			in: tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+		},
+		"valid json object": {
+			in: tftypes.NewValue(tftypes.String, `{"hello":"world", "array": [1, 2, 3]}`),
+		},
+		"valid json array": {
+			in: tftypes.NewValue(tftypes.String, `["hello", "world"]`),
+		},
+		"invalid json - bracket mismatch": {
+			in: tftypes.NewValue(tftypes.String, `{"hello":"world"`),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid JSON String Value",
+					"A string value was provided that is not valid JSON string format (RFC 7159).\n\n"+
+						"Given Value: {\"hello\":\"world\"\n",
+				),
+			},
+		},
+		"invalid json - normal string": {
+			in: tftypes.NewValue(tftypes.String, "notvalidjson123"),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid JSON String Value",
+					"A string value was provided that is not valid JSON string format (RFC 7159).\n\n"+
+						"Given Value: notvalidjson123\n",
+				),
+			},
+		},
+		"wrong-value-type": {
+			in: tftypes.NewValue(tftypes.Number, 123),
+			expectedDiags: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Lossy JSON Type Validation Error",
+					"An unexpected error was encountered trying to validate an attribute value. This is always an error in the provider. Please report the following to the provider developer:\n\n"+
+						"expected String value, received tftypes.Value with value: tftypes.Number<\"123\">",
+				),
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := LossyJsonType{}.Validate(context.Background(), testCase.in, path.Root("test"))
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}
+
+func TestLossyJsonTypeValueFromTerraform(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		in          tftypes.Value
+		expectation attr.Value
+		expectedErr string
+	}{
+		"true": {
+			in:          tftypes.NewValue(tftypes.String, `{"hello":"world"}`),
+			expectation: NewLossyJsonValue(`{"hello":"world"}`),
+		},
+		"unknown": {
+			in:          tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+			expectation: NewLossyJsonUnknown(),
+		},
+		"null": {
+			in:          tftypes.NewValue(tftypes.String, nil),
+			expectation: NewLossyJsonNull(),
+		},
+		"wrongType": {
+			in:          tftypes.NewValue(tftypes.Number, 123),
+			expectedErr: "can't unmarshal tftypes.Number into *string, expected string",
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			got, err := LossyJsonType{}.ValueFromTerraform(ctx, testCase.in)
+			if err != nil {
+				if testCase.expectedErr == "" {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				if testCase.expectedErr != err.Error() {
+					t.Fatalf("Expected error to be %q, got %q", testCase.expectedErr, err.Error())
+				}
+				return
+			}
+			if err == nil && testCase.expectedErr != "" {
+				t.Fatalf("Expected error to be %q, didn't get an error", testCase.expectedErr)
+			}
+			if !got.Equal(testCase.expectation) {
+				t.Errorf("Expected %+v, got %+v", testCase.expectation, got)
+			}
+			if testCase.expectation.IsNull() != testCase.in.IsNull() {
+				t.Errorf("Expected null-ness match: expected %t, got %t", testCase.expectation.IsNull(), testCase.in.IsNull())
+			}
+			if testCase.expectation.IsUnknown() != !testCase.in.IsKnown() {
+				t.Errorf("Expected unknown-ness match: expected %t, got %t", testCase.expectation.IsUnknown(), !testCase.in.IsKnown())
+			}
+		})
+	}
+}

--- a/internal/sentrytypes/lossy_json_value.go
+++ b/internal/sentrytypes/lossy_json_value.go
@@ -1,0 +1,209 @@
+package sentrytypes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var _ basetypes.StringValuable = (*LossyJson)(nil)
+var _ basetypes.StringValuableWithSemanticEquals = (*LossyJson)(nil)
+
+type LossyJson struct {
+	basetypes.StringValue
+}
+
+func (v LossyJson) Type(_ context.Context) attr.Type {
+	return LossyJsonType{}
+}
+
+func (v LossyJson) Equal(o attr.Value) bool {
+	other, ok := o.(LossyJson)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+func (v LossyJson) StringSemanticEquals(_ context.Context, newValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	newValue, ok := newValuable.(LossyJson)
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", newValuable),
+		)
+
+		return false, diags
+	}
+
+	result, err := lossyJsonEqual(newValue.ValueString(), v.ValueString())
+
+	if err != nil {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected error occurred while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return false, diags
+	}
+
+	return result, diags
+}
+
+func lossyJsonEqual(s1, s2 string) (bool, error) {
+	v1, err := decodeJson(s1)
+	if err != nil {
+		return false, err
+	}
+
+	v2, err := decodeJson(s2)
+	if err != nil {
+		return false, err
+	}
+
+	return deepLossyEqual(v1, v2), nil
+}
+
+func decodeJson(s string) (interface{}, error) {
+	dec := json.NewDecoder(strings.NewReader(s))
+	dec.UseNumber()
+
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+func deepLossyEqual(v1, v2 interface{}) bool {
+	switch v1 := v1.(type) {
+	case bool:
+		v2, ok := v2.(bool)
+		if !ok {
+			return false
+		}
+		return v1 == v2
+	case json.Number:
+		switch v2 := v2.(type) {
+		case json.Number:
+			return v1.String() == v2.String()
+		case string:
+			return v1.String() == v2
+		default:
+			return false
+		}
+	case string:
+		switch v2 := v2.(type) {
+		case json.Number:
+			return v1 == v2.String()
+		case string:
+			return v1 == v2
+		default:
+			return false
+		}
+	case []interface{}:
+		v2, ok := v2.([]interface{})
+		if !ok {
+			return false
+		}
+
+		if len(v1) != len(v2) {
+			return false
+		}
+
+		for i := 0; i < len(v1); i++ {
+			if !deepLossyEqual(v1[i], v2[i]) {
+				return false
+			}
+		}
+
+		return true
+	case map[string]interface{}:
+		v2, ok := v2.(map[string]interface{})
+		if !ok {
+			return false
+		}
+
+		if len(v1) > len(v2) {
+			return false
+		}
+
+		// Check that all keys in v1 are in v2 but not the other way around (lossy)
+		for k := range v1 {
+			v2Val, ok := v2[k]
+			if !ok {
+				return false
+			}
+
+			if !deepLossyEqual(v1[k], v2Val) {
+				return false
+			}
+		}
+
+		return true
+	case nil:
+		return v2 == nil
+	default:
+		panic(fmt.Sprintf("unexpected type %T", v1))
+	}
+}
+
+func (v LossyJson) Unmarshal(target any) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if v.IsNull() {
+		diags.Append(diag.NewErrorDiagnostic("Lossy JSON Unmarshal Error", "json string value is null"))
+		return diags
+	}
+
+	if v.IsUnknown() {
+		diags.Append(diag.NewErrorDiagnostic("Lossy JSON Unmarshal Error", "json string value is unknown"))
+		return diags
+	}
+
+	err := json.Unmarshal([]byte(v.ValueString()), target)
+	if err != nil {
+		diags.Append(diag.NewErrorDiagnostic("Lossy JSON Unmarshal Error", err.Error()))
+	}
+
+	return diags
+}
+
+func NewLossyJsonNull() LossyJson {
+	return LossyJson{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+func NewLossyJsonUnknown() LossyJson {
+	return LossyJson{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+func NewLossyJsonValue(value string) LossyJson {
+	return LossyJson{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+func NewLossyJsonPointerValue(value *string) LossyJson {
+	return LossyJson{
+		StringValue: basetypes.NewStringPointerValue(value),
+	}
+}

--- a/internal/sentrytypes/lossy_json_value_test.go
+++ b/internal/sentrytypes/lossy_json_value_test.go
@@ -1,0 +1,247 @@
+package sentrytypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestLossyJsonStringSemanticEquals(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		currentJson   LossyJson
+		givenJson     basetypes.StringValuable
+		expectedMatch bool
+		expectedDiags diag.Diagnostics
+	}{
+		"not equal - mismatched field values": {
+			currentJson:   NewLossyJsonValue(`{"hello": "dlrow", "nums": [3, 2, 1], "nested": {"test-bool": false}}`),
+			givenJson:     NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			expectedMatch: false,
+		},
+		"not equal - mismatched field names": {
+			currentJson:   NewLossyJsonValue(`{"Hello": "world", "Nums": [1, 2, 3], "Nested": {"Test-bool": true}}`),
+			givenJson:     NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			expectedMatch: false,
+		},
+		"not equal - array item order difference": {
+			currentJson:   NewLossyJsonValue(`[{"nums":[1, 2, 3]}, {"hello": "world"}, {"nested": {"test-bool": true}}]`),
+			givenJson:     NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true}}]`),
+			expectedMatch: false,
+		},
+		"semantically equal - null match": {
+			currentJson:   NewLossyJsonValue(`null`),
+			givenJson:     NewLossyJsonValue(`null`),
+			expectedMatch: true,
+		},
+		"semantically equal - object byte-for-byte match": {
+			currentJson:   NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			givenJson:     NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			expectedMatch: true,
+		},
+		"semantically equal - array byte-for-byte match": {
+			currentJson:   NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true}}]`),
+			givenJson:     NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true}}]`),
+			expectedMatch: true,
+		},
+		"semantically equal - object field order difference": {
+			currentJson:   NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			givenJson:     NewLossyJsonValue(`{"nums": [1, 2, 3], "nested": {"test-bool": true}, "hello": "world"}`),
+			expectedMatch: true,
+		},
+		"semantically equal - object whitespace difference": {
+			currentJson: NewLossyJsonValue(`{
+				"hello": "world",
+				"nums": [1, 2, 3],
+				"nested": {
+					"test-bool": true
+				}
+			}`),
+			givenJson:     NewLossyJsonValue(`{"hello":"world","nums":[1,2,3],"nested":{"test-bool":true}}`),
+			expectedMatch: true,
+		},
+		"semantically equal - array whitespace difference": {
+			currentJson: NewLossyJsonValue(`[
+				{
+				  "hello": "world"
+				},
+				{
+				  "nums": [
+					1,
+					2,
+					3
+				  ]
+				},
+				{
+				  "nested": {
+					"test-bool": true
+				  }
+				}
+			  ]`),
+			givenJson:     NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true}}]`),
+			expectedMatch: true,
+		},
+		"error - invalid json": {
+			currentJson:   NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			givenJson:     NewLossyJsonValue(`&#$^"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			expectedMatch: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Semantic Equality Check Error",
+					"An unexpected error occurred while performing semantic equality checks. "+
+						"Please report this to the provider developers.\n\n"+
+						"Error: invalid character '&' looking for beginning of value",
+				),
+			},
+		},
+		"error - not given lossy json value": {
+			currentJson:   NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			givenJson:     basetypes.NewStringValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			expectedMatch: false,
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Semantic Equality Check Error",
+					"An unexpected value type was received while performing semantic equality checks. "+
+						"Please report this to the provider developers.\n\n"+
+						"Expected Value Type: sentrytypes.LossyJson\n"+
+						"Got Value Type: basetypes.StringValue",
+				),
+			},
+		},
+		// JSON Semantic equality uses (decoder).UseNumber to avoid Go parsing JSON numbers into float64. This ensures that Go
+		// won't normalize the JSON number representation or impose limits on numeric range.
+		"not equal - different JSON number representations": {
+			currentJson:   NewLossyJsonValue(`{"large": 12423434}`),
+			givenJson:     NewLossyJsonValue(`{"large": 1.2423434e+07}`),
+			expectedMatch: false,
+		},
+		"semantically equal - larger than max float64 values": {
+			currentJson:   NewLossyJsonValue(`{"large": 1.79769313486231570814527423731704356798070e+309}`),
+			givenJson:     NewLossyJsonValue(`{"large": 1.79769313486231570814527423731704356798070e+309}`),
+			expectedMatch: true,
+		},
+		// JSON Semantic equality uses Go's encoding/json library, which replaces some characters to escape codes
+		"semantically equal - HTML escape characters are equal": {
+			currentJson:   NewLossyJsonValue(`{"url_ampersand": "http://example.com?foo=bar&hello=world", "left-caret": "<", "right-caret": ">"}`),
+			givenJson:     NewLossyJsonValue(`{"url_ampersand": "http://example.com?foo=bar\u0026hello=world", "left-caret": "\u003c", "right-caret": "\u003e"}`),
+			expectedMatch: true,
+		},
+		"semantically equal (lossy) - string number representation": {
+			currentJson:   NewLossyJsonValue(`{"large": "12423434"}`),
+			givenJson:     NewLossyJsonValue(`{"large": 12423434}`),
+			expectedMatch: true,
+		},
+		"semantically equal (lossy) - object additional field": {
+			currentJson:   NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}, "new-field": null}`),
+			givenJson:     NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "nested": {"test-bool": true}}`),
+			expectedMatch: true,
+		},
+		"semantically equal (lossy) - array additional field": {
+			currentJson:   NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true, "new-field": null}}]`),
+			givenJson:     NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true}}]`),
+			expectedMatch: true,
+		},
+		"not equal (lossy) - object missing field": {
+			currentJson:   NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true}}]`),
+			givenJson:     NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true, "new-field": null}}]`),
+			expectedMatch: false,
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			match, diags := testCase.currentJson.StringSemanticEquals(context.Background(), testCase.givenJson)
+
+			if testCase.expectedMatch != match {
+				t.Errorf("Expected StringSemanticEquals to return: %t, but got: %t", testCase.expectedMatch, match)
+			}
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}
+
+func TestLossyJsonUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		json          LossyJson
+		target        any
+		output        any
+		expectedDiags diag.Diagnostics
+	}{
+		"lossy value is null ": {
+			json: NewLossyJsonNull(),
+			target: struct {
+				Hello string `json:"hello"`
+			}{},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Lossy JSON Unmarshal Error",
+					"json string value is null",
+				),
+			},
+		},
+		"lossy value is unknown ": {
+			json: NewLossyJsonUnknown(),
+			target: struct {
+				Hello string `json:"hello"`
+			}{},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Lossy JSON Unmarshal Error",
+					"json string value is unknown",
+				),
+			},
+		},
+		"invalid target - not a pointer ": {
+			json: NewLossyJsonValue(`{"hello": "world"}`),
+			target: struct {
+				Hello string `json:"hello"`
+			}{},
+			expectedDiags: diag.Diagnostics{
+				diag.NewErrorDiagnostic(
+					"Lossy JSON Unmarshal Error",
+					"json: Unmarshal(non-pointer struct { Hello string \"json:\\\"hello\\\"\" })",
+				),
+			},
+		},
+		"valid target ": {
+			json: NewLossyJsonValue(`{"hello": "world", "nums": [1, 2, 3], "test-bool": true}`),
+			target: &struct {
+				Hello   string `json:"hello"`
+				Numbers []int  `json:"nums"`
+				Test    bool   `json:"test-bool"`
+			}{},
+			output: &struct {
+				Hello   string `json:"hello"`
+				Numbers []int  `json:"nums"`
+				Test    bool   `json:"test-bool"`
+			}{
+				Hello:   "world",
+				Numbers: []int{1, 2, 3},
+				Test:    true,
+			},
+		},
+	}
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := testCase.json.Unmarshal(testCase.target)
+
+			if diff := cmp.Diff(diags, testCase.expectedDiags); diff != "" {
+				t.Errorf("Unexpected diagnostics (-got, +expected): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Work with Sentry API's inconsistent request/response formats and data types:

1. Sentry occasionally accepts a string but returns an integer, and sometimes does the opposite.
2. Sentry might return additional keys in an object beyond those provided.