### PR TITLE
fix: sentry_issue_alert.conditions empty array

### DIFF
--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -55,7 +55,7 @@ func (m *IssueAlertResourceModel) Fill(organization string, alert sentry.IssueAl
 	m.FilterMatch = types.StringPointerValue(alert.FilterMatch)
 	m.Owner = types.StringPointerValue(alert.Owner)
 
-	m.Conditions = sentrytypes.NewLossyJsonNull()
+	m.Conditions = sentrytypes.NewLossyJsonValue("[]")
 	if len(alert.Conditions) > 0 {
 		if conditions, err := json.Marshal(alert.Conditions); err == nil {
 			m.Conditions = sentrytypes.NewLossyJsonValue(string(conditions))


### PR DESCRIPTION
Conditions are required, but can be set as empty array.

Previously if empty array would be set in tf config, null would be set in tf state after apply, which causes configuration missmatch.

Now if empty array set in tf config, empty array will be set in tf state.

Should fix https://github.com/jianyuan/terraform-provider-sentry/issues/366