### PR TITLE
docs: update `spike-protection` in `sentry_notification_action`

### DIFF
--- a/docs/resources/notification_action.md
+++ b/docs/resources/notification_action.md
@@ -41,7 +41,7 @@ resource "sentry_notification_action" "default" {
 - `organization` (String) The slug of the organization the project belongs to.
 - `projects` (List of String) The list of project slugs that the Notification Action is created for.
 - `service_type` (String) The service that is used for sending the notification.
-- `trigger_type` (String) The type of trigger that will activate this action. Valid values are `spike_protection`.
+- `trigger_type` (String) The type of trigger that will activate this action. Valid values are `spike-protection`.
 
 ### Optional
 


### PR DESCRIPTION
Fix misspelled `trigger_type` value.

Valid value are `spike-protection` or `audit-log`. 

```
Error creating notification action: POST
│ https://sentry.io/api/0/organizations/REDACTED/notifications/actions/: 400
│ map[triggerType:[Invalid trigger selected. Choose from 'audit-log' and
│ 'spike-protection'.]]

```