### PR TITLE
fix: Convert sentry_project_inbound_data_filter.subfilters to set from list

### DIFF
--- a/internal/provider/resource_project_inbound_data_filter.go
+++ b/internal/provider/resource_project_inbound_data_filter.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -35,7 +35,7 @@ type ProjectInboundDataFilterResourceModel struct {
 	Project      types.String `tfsdk:"project"`
 	FilterId     types.String `tfsdk:"filter_id"`
 	Active       types.Bool   `tfsdk:"active"`
-	Subfilters   types.List   `tfsdk:"subfilters"`
+	Subfilters   types.Set    `tfsdk:"subfilters"`
 }
 
 func (m *ProjectInboundDataFilterResourceModel) Fill(organization string, project string, filterId string, filter sentry.ProjectInboundDataFilter) error {
@@ -52,7 +52,7 @@ func (m *ProjectInboundDataFilterResourceModel) Fill(organization string, projec
 			subfilterElements = append(subfilterElements, types.StringValue(subfilter))
 		}
 
-		m.Subfilters = types.ListValueMust(types.StringType, subfilterElements)
+		m.Subfilters = types.SetValueMust(types.StringType, subfilterElements)
 	}
 
 	return nil
@@ -95,12 +95,12 @@ func (r *ProjectInboundDataFilterResource) Schema(ctx context.Context, req resou
 					),
 				},
 			},
-			"subfilters": schema.ListAttribute{
+			"subfilters": schema.SetAttribute{
 				Description: "Specifies which legacy browser filters should be active. Anything excluded from the list will be disabled. See the [Sentry documentation](https://docs.sentry.io/api/projects/update-an-inbound-data-filter/) for a list of available subfilters.",
 				Optional:    true,
 				ElementType: types.StringType,
-				Validators: []validator.List{
-					listvalidator.ConflictsWith(
+				Validators: []validator.Set{
+					setvalidator.ConflictsWith(
 						path.MatchRelative().AtParent().AtName("active"),
 					),
 				},

--- a/internal/provider/resource_project_inbound_data_filter_test.go
+++ b/internal/provider/resource_project_inbound_data_filter_test.go
@@ -58,25 +58,28 @@ func TestAccProjectInboundDataFilterResource_LegacyBrowser(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectInboundDataFilterConfig(team, project, filterId, "subfilters = [\"ie_pre_9\"]"),
+				Config: testAccProjectInboundDataFilterConfig(team, project, filterId, "subfilters = [\"android_pre_4\", \"ie_pre_9\"]"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rn, "organization", acctest.TestOrganization),
 					resource.TestCheckResourceAttr(rn, "project", project),
 					resource.TestCheckResourceAttr(rn, "filter_id", filterId),
 					resource.TestCheckNoResourceAttr(rn, "active"),
-					resource.TestCheckResourceAttr(rn, "subfilters.#", "1"),
-					resource.TestCheckResourceAttr(rn, "subfilters.0", "ie_pre_9"),
+					resource.TestCheckResourceAttr(rn, "subfilters.#", "2"),
+					resource.TestCheckResourceAttr(rn, "subfilters.0", "android_pre_4"),
+					resource.TestCheckResourceAttr(rn, "subfilters.1", "ie_pre_9"),
 				),
 			},
+			// NOTE: Intentionally not sorting subfilters to show that the order does not matter during import.
 			{
-				Config: testAccProjectInboundDataFilterConfig(team, project, filterId, "subfilters = [\"safari_pre_6\"]"),
+				Config: testAccProjectInboundDataFilterConfig(team, project, filterId, "subfilters = [\"safari_pre_6\", \"android_pre_4\"]"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(rn, "organization", acctest.TestOrganization),
 					resource.TestCheckResourceAttr(rn, "project", project),
 					resource.TestCheckResourceAttr(rn, "filter_id", filterId),
 					resource.TestCheckNoResourceAttr(rn, "active"),
-					resource.TestCheckResourceAttr(rn, "subfilters.#", "1"),
+					resource.TestCheckResourceAttr(rn, "subfilters.#", "2"),
 					resource.TestCheckResourceAttr(rn, "subfilters.0", "safari_pre_6"),
+					resource.TestCheckResourceAttr(rn, "subfilters.1", "android_pre_4"),
 				),
 			},
 			{


### PR DESCRIPTION
The order of subfilters supplied in Terraform and the value returned by the API may not match. This is fixed by converting subfilters into a Terraform Set from a Terraform List.