### PR TITLE
ref: update `sentry_issue_alert` Slack example with notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,13 +44,29 @@ provider "sentry" {
 ## Example Usage
 
 ```terraform
-# Configure the Sentry Provider
+# Configure the Sentry Provider for US data storage location (default)
 provider "sentry" {
   token = var.sentry_auth_token
 
-  # If you are self-hosting Sentry, set the base URL here.
+  # If you want to be explicit, you can specify the base URL for the US region.
+  # base_url = "https://us.sentry.io/api/"
+  # or
+  # base_url = "https://sentry.io/api/"
+}
+
+# Configure the Sentry Provider for EU data storage location
+provider "sentry" {
+  token = var.sentry_auth_token
+
+  base_url = "https://de.sentry.io/api/"
+}
+
+# Configure the Sentry Provider for self-hosted Sentry
+provider "sentry" {
+  token = var.sentry_auth_token
+
   # The URL format must be "https://[hostname]/api/".
-  # base_url = "https://example.com/api/"
+  base_url = "https://example.com/api/"
 }
 ```
 
@@ -59,7 +75,7 @@ provider "sentry" {
 
 ### Optional
 
-- `base_url` (String) The target Sentry Base API URL in the format `https://[hostname]/api/`. The default value is `https://sentry.io/api/`. The value must be provided when working with Sentry On-Premise. The value can be sourced from the `SENTRY_BASE_URL` environment variable.
+- `base_url` (String) The target Sentry Base API URL follows the format `https://[hostname]/api/`. The default value is `https://sentry.io/api/`, which is an alias for `https://us.sentry.io/api/` (US data storage location). To change the data storage location to the EU, set the value to `https://de.sentry.io/api/`. This value is required for non-US storage locations or Sentry On-Premise deployments. The value can be sourced from the `SENTRY_BASE_URL` environment variable.
 - `token` (String, Sensitive) The authentication token used to connect to Sentry. The value can be sourced from the `SENTRY_AUTH_TOKEN` environment variable.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,12 @@
 ---
 page_title: "Official Sentry Terraform Provider"
 description: |-
-  The Terraform provider for Sentry allows teams to configure and update Sentry project parameters via their command line. This provider is built and maintained by a community developer and officially sponsored by Sentry.
+  Set up Sentry Team, Projects, Alerts, and more. This provider is maintained with [Sentry.io](https://sentry.io)'s sponsorship. Please add any bug reports/feature requests in the GitHub repo.
 ---
 
 # Official Sentry Terraform Provider
 
-The Sentry Terraform provider is an open-source project built and maintained by a community developer and officially sponsored by [Sentry](https://sentry.io).
-
-The Sentry Terraform provider allows your team to configure and update Sentry project parameters including Projects, Alerts (Issues & Transactions), Dashboards, Teams, and Organizations - programmatically. This helps you easily provision Sentry while also giving you the option to work from an interface you are already familiar with. If you have questions, feature requests, or issues you'd like to report, please [contact Sentry](https://help.sentry.io/) or click on 'report an issue' to the right.
+Set up Sentry Team, Projects, Alerts, and more. This provider is maintained with [Sentry.io](https://sentry.io)'s sponsorship. Please add any bug reports/feature requests in the [GitHub repo](https://github.com/jianyuan/terraform-provider-sentry/issues).
 
 This provider utilizes the [Web APIs](https://docs.sentry.io/api/) to interact with Sentry resources.
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,8 +1,24 @@
-# Configure the Sentry Provider
+# Configure the Sentry Provider for US data storage location (default)
 provider "sentry" {
   token = var.sentry_auth_token
 
-  # If you are self-hosting Sentry, set the base URL here.
+  # If you want to be explicit, you can specify the base URL for the US region.
+  # base_url = "https://us.sentry.io/api/"
+  # or
+  # base_url = "https://sentry.io/api/"
+}
+
+# Configure the Sentry Provider for EU data storage location
+provider "sentry" {
+  token = var.sentry_auth_token
+
+  base_url = "https://de.sentry.io/api/"
+}
+
+# Configure the Sentry Provider for self-hosted Sentry
+provider "sentry" {
+  token = var.sentry_auth_token
+
   # The URL format must be "https://[hostname]/api/".
-  # base_url = "https://example.com/api/"
+  base_url = "https://example.com/api/"
 }

--- a/examples/resources/sentry_issue_alert/resource.tf
+++ b/examples/resources/sentry_issue_alert/resource.tf
@@ -167,7 +167,8 @@ resource "sentry_issue_alert" "slack_alert" {
     "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
     "workspace": ${parseint(data.sentry_organization_integration.slack.id, 10)},
     "channel": "#warning",
-    "tags": "environment,level"
+    "tags": "environment,level",
+    "notes": "Please <http://example.com|click here> for triage information"
   }
 ]
 EOT

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -43,7 +43,7 @@ func (p *SentryProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 				Sensitive:           true,
 			},
 			"base_url": schema.StringAttribute{
-				MarkdownDescription: "The target Sentry Base API URL in the format `https://[hostname]/api/`. The default value is `https://sentry.io/api/`. The value must be provided when working with Sentry On-Premise. The value can be sourced from the `SENTRY_BASE_URL` environment variable.",
+				MarkdownDescription: "The target Sentry Base API URL follows the format `https://[hostname]/api/`. The default value is `https://sentry.io/api/`, which is an alias for `https://us.sentry.io/api/` (US data storage location). To change the data storage location to the EU, set the value to `https://de.sentry.io/api/`. This value is required for non-US storage locations or Sentry On-Premise deployments. The value can be sourced from the `SENTRY_BASE_URL` environment variable.",
 				Optional:            true,
 			},
 		},

--- a/sentry/provider.go
+++ b/sentry/provider.go
@@ -20,17 +20,14 @@ func NewProvider(version string) func() *schema.Provider {
 		p := &schema.Provider{
 			Schema: map[string]*schema.Schema{
 				"token": {
-					Description: "The authentication token used to connect to Sentry. The value can be sourced from " +
-						"the `SENTRY_AUTH_TOKEN` environment variable.",
+					Description: "The authentication token used to connect to Sentry. The value can be sourced from the `SENTRY_AUTH_TOKEN` environment variable.",
 					Type:        schema.TypeString,
 					Optional:    true,
 					DefaultFunc: schema.MultiEnvDefaultFunc([]string{"SENTRY_AUTH_TOKEN", "SENTRY_TOKEN"}, nil),
 					Sensitive:   true,
 				},
 				"base_url": {
-					Description: "The target Sentry Base API URL in the format `https://[hostname]/api/`. " +
-						"The default value is `https://sentry.io/api/`. The value must be provided when working with " +
-						"Sentry On-Premise. The value can be sourced from the `SENTRY_BASE_URL` environment variable.",
+					Description: "The target Sentry Base API URL follows the format `https://[hostname]/api/`. The default value is `https://sentry.io/api/`, which is an alias for `https://us.sentry.io/api/` (US data storage location). To change the data storage location to the EU, set the value to `https://de.sentry.io/api/`. This value is required for non-US storage locations or Sentry On-Premise deployments. The value can be sourced from the `SENTRY_BASE_URL` environment variable.",
 					Type:        schema.TypeString,
 					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("SENTRY_BASE_URL", "https://sentry.io/api/"),

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,14 +1,12 @@
 ---
 page_title: "Official Sentry Terraform Provider"
 description: |-
-  The Terraform provider for Sentry allows teams to configure and update Sentry project parameters via their command line. This provider is built and maintained by a community developer and officially sponsored by Sentry.
+  Set up Sentry Team, Projects, Alerts, and more. This provider is maintained with [Sentry.io](https://sentry.io)'s sponsorship. Please add any bug reports/feature requests in the GitHub repo.
 ---
 
 # Official Sentry Terraform Provider
 
-The Sentry Terraform provider is an open-source project built and maintained by a community developer and officially sponsored by [Sentry](https://sentry.io).
-
-The Sentry Terraform provider allows your team to configure and update Sentry project parameters including Projects, Alerts (Issues & Transactions), Dashboards, Teams, and Organizations - programmatically. This helps you easily provision Sentry while also giving you the option to work from an interface you are already familiar with. If you have questions, feature requests, or issues you'd like to report, please [contact Sentry](https://help.sentry.io/) or click on 'report an issue' to the right.
+Set up Sentry Team, Projects, Alerts, and more. This provider is maintained with [Sentry.io](https://sentry.io)'s sponsorship. Please add any bug reports/feature requests in the [GitHub repo](https://github.com/jianyuan/terraform-provider-sentry/issues).
 
 This provider utilizes the [Web APIs](https://docs.sentry.io/api/) to interact with Sentry resources.
 


### PR DESCRIPTION
Edit `sentry_issue_alert` documentation with an example on how to set a Slack note - Text to show alongside the notification