### PR TITLE
feat: Adds support for `comparison_delta` to `sentry_metric_alert`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
-	github.com/jianyuan/go-sentry/v2 v2.8.0
+	github.com/jianyuan/go-sentry/v2 v2.8.1
 	golang.org/x/oauth2 v0.20.0
 	golang.org/x/sync v0.7.0
 )

--- a/sentry/resource_sentry_metric_alert.go
+++ b/sentry/resource_sentry_metric_alert.go
@@ -86,6 +86,11 @@ func resourceSentryMetricAlert() *schema.Resource {
 				Optional:    true,
 				Description: "The value at which the Alert rule resolves",
 			},
+			"comparison_delta": {
+				Type:        schema.TypeFloat,
+				Optional:    true,
+				Description: "An optional int representing the time delta to use as the comparison period, in minutes. Required when using a percentage change threshold",
+			},
 			"trigger": {
 				Type:     schema.TypeList,
 				Required: true,
@@ -189,6 +194,9 @@ func resourceSentryMetricAlertObject(d *schema.ResourceData) *sentry.MetricAlert
 	}
 	if v, ok := d.GetOk("resolve_threshold"); ok {
 		alert.ResolveThreshold = sentry.Float64(v.(float64))
+	}
+	if v, ok := d.GetOk("comparison_delta"); ok {
+		alert.ComparisonDelta = sentry.Float64(v.(float64))
 	}
 	if v, ok := d.GetOk("owner"); ok {
 		alert.Owner = sentry.String(v.(string))

--- a/sentry/resource_sentry_metric_alert_test.go
+++ b/sentry/resource_sentry_metric_alert_test.go
@@ -35,6 +35,7 @@ func TestAccSentryMetricAlert_basic(t *testing.T) {
 			resource.TestCheckResourceAttr(rn, "time_window", "50"),
 			resource.TestCheckResourceAttr(rn, "threshold_type", "0"),
 			resource.TestCheckResourceAttr(rn, "resolve_threshold", "100"),
+			resource.TestCheckResourceAttr(rn, "comparison_delta", "100"),
 			resource.TestCheckResourceAttrPtr(rn, "internal_id", &alertID),
 		)
 	}
@@ -126,6 +127,7 @@ resource "sentry_metric_alert" "test" {
 	time_window       = 50.0
 	threshold_type    = 0
 	resolve_threshold = 100.0
+	comparison_delta  = 100.0
 
 	trigger {
 		action {


### PR DESCRIPTION
This closes https://github.com/jianyuan/terraform-provider-sentry/issues/406