### PR TITLE
Gracefully handle 404 in team member resource

### DIFF
--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -275,8 +276,11 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	effectiveRole, err := r.getEffectiveTeamRole(ctx, data.Organization.ValueString(), data.MemberId.ValueString(), data.Team.ValueString())
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", err.Error())
-		resp.State.RemoveResource(ctx)
+		if strings.Contains(err.Error(), "404 The requested resource does not exist") {
+			resp.State.RemoveResource(ctx)
+		} else {
+			resp.Diagnostics.AddError("Client Error", err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
This PR makes the `team_member` resource handle 404s more gracefully. Previously, 404s on organization members will block `terraform apply`. Now it doesn't.

Related to #446. This PR doesn't close that issue because there may be other places that requires similar changes.