### PR TITLE
Increase alert name limit to the real limit

### DIFF
--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -131,7 +131,7 @@ Please note the following changes since v0.12.0:
 				MarkdownDescription: "The issue alert name.",
 				Required:            true,
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(1, 64),
+					stringvalidator.LengthBetween(1, 255),
 				},
 			},
 			"conditions": schema.StringAttribute{

--- a/internal/provider/resource_issue_alert_test.go
+++ b/internal/provider/resource_issue_alert_test.go
@@ -74,7 +74,7 @@ func TestAccIssueAlertResource_MigrateFromPluginSDK(t *testing.T) {
 	rn := "sentry_issue_alert.test"
 	team := acctest.RandomWithPrefix("tf-team")
 	project := acctest.RandomWithPrefix("tf-project")
-	alert := acctest.RandomWithPrefix("tf-issue-alert")
+	alert := acctest.RandomWithPrefix("tf-issue-alert-with-a-very-looooong-name-greater-than-64-characters")
 	var alertId string
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
The Sentry UI allows alert names of up to 256 characters:
![Screenshot](https://github.com/user-attachments/assets/4af3137b-31a5-4303-ba99-b76ef4010f35)

However, the provider was limiting the name to 64 characters.

NOTE: I don't have a Sentry test environment, but I verified that this change builds, and did add a test with a longer name