### PR TITLE
Feat project filters

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -25,6 +25,12 @@ resource "sentry_project" "default" {
   resolve_age = 720
 
   default_rules = false
+
+  filters = {
+    blacklisted_ips = ["127.0.0.1", "0.0.0.0/8"]
+    releases        = ["1.*", "[!3].[0-9].*"]
+    error_messages  = ["TypeError*", "*: integer division or modulo by zero"]
+  }
 }
 ```
 
@@ -59,9 +65,9 @@ resource "sentry_project" "default" {
 
 Optional:
 
-- `blacklisted_ips` (Set of String) Filter events from these IP addresses.
-- `error_messages` (Set of String) Filter events by error messages. Allows [glob pattern matching](https://en.wikipedia.org/wiki/Glob_(programming)).
-- `releases` (Set of String) Filter events from these releases. Allows [glob pattern matching](https://en.wikipedia.org/wiki/Glob_(programming)).
+- `blacklisted_ips` (Set of String) Filter events from these IP addresses. (e.g. 127.0.0.1 or 10.0.0.0/8)
+- `error_messages` (Set of String) Filter events by error messages. Allows [glob pattern matching](https://en.wikipedia.org/wiki/Glob_(programming)). (e.g. TypeError* or *: integer division or modulo by zero)
+- `releases` (Set of String) Filter events from these releases. Allows [glob pattern matching](https://en.wikipedia.org/wiki/Glob_(programming)). (e.g. 1.* or [!3].[0-9].*)
 
 ## Import
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -43,6 +43,7 @@ resource "sentry_project" "default" {
 - `default_rules` (Boolean) Whether to create a default issue alert. Defaults to true where the behavior is to alert the user on every new issue.
 - `digests_max_delay` (Number) The maximum amount of time (in seconds) to wait between scheduling digests for delivery.
 - `digests_min_delay` (Number) The minimum amount of time (in seconds) to wait between scheduling digests for delivery after the initial scheduling.
+- `filters` (Attributes) Custom filters for this project. (see [below for nested schema](#nestedatt--filters))
 - `platform` (String) The platform for this project. For a list of valid values, [see this page](https://github.com/jianyuan/terraform-provider-sentry/blob/main/internal/sentryplatforms/platforms.txt). Use `other` for platforms not listed.
 - `resolve_age` (Number) Hours in which an issue is automatically resolve if not seen after this amount of time.
 - `slug` (String) The optional slug for this project.
@@ -52,6 +53,15 @@ resource "sentry_project" "default" {
 - `features` (Set of String)
 - `id` (String) The ID of this resource.
 - `internal_id` (String) The internal ID for this project.
+
+<a id="nestedatt--filters"></a>
+### Nested Schema for `filters`
+
+Optional:
+
+- `blacklisted_ips` (Set of String) Filter events from these IP addresses.
+- `error_messages` (Set of String) Filter events by error messages. Allows [glob pattern matching](https://en.wikipedia.org/wiki/Glob_(programming)).
+- `releases` (Set of String) Filter events from these releases. Allows [glob pattern matching](https://en.wikipedia.org/wiki/Glob_(programming)).
 
 ## Import
 

--- a/examples/resources/sentry_project/resource.tf
+++ b/examples/resources/sentry_project/resource.tf
@@ -10,4 +10,10 @@ resource "sentry_project" "default" {
   resolve_age = 720
 
   default_rules = false
+
+  filters = {
+    blacklisted_ips = ["127.0.0.1", "0.0.0.0/8"]
+    releases        = ["1.*", "[!3].[0-9].*"]
+    error_messages  = ["TypeError*", "*: integer division or modulo by zero"]
+  }
 }


### PR DESCRIPTION
This PR introduces the ability to configure custom filters for the project resource. The custom filters are blacklisted IPs, error messages, and releases.

Closes #455