### PR TITLE
doc: add note section on the token for organization member management

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ It's best practice not to store the authentication token in plain text. As an al
 provider "sentry" {}
 ```
 
-~> **NOTE:** Integration tokens are tied to the organization, not a specific user. Meaning, they cannot be used to invite/delete users, because the scopes do not include permissions at this high of a level. A personal auth token tied to your user role will be able to perform these specific actions if your user is a Manager or Owner is needed for Organization members.
+~> **NOTE:** Integration tokens are tied to the organization, not a specific user. Meaning, they cannot be used to invite/delete users, because the scopes do not include permissions at this high of a level. A personal auth token tied to your user role will be able to perform Organization's members' actions if your user is a Manager or Owner.
 
 ### Self-hosted Sentry
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,7 @@
 ---
+# Generated from templates/index.md.tmpl
+# DO NOT EDIT DIRECTLY
+
 page_title: "Official Sentry Terraform Provider"
 description: |-
   Set up Sentry Team, Projects, Alerts, and more. This provider is maintained with [Sentry.io](https://sentry.io)'s sponsorship. Please add any bug reports/feature requests in the GitHub repo.
@@ -28,7 +31,7 @@ It's best practice not to store the authentication token in plain text. As an al
 provider "sentry" {}
 ```
 
-~> **NOTE:** Integration tokens are tied to the organization, not a specific user. Meaning, they cannot be used to invite/delete users, because the scopes do not include permissions at this high of a level. A personal auth token tied to your user role will be able to perform Organization's members' actions if your user is a Manager or Owner.
+**NOTE:** Integration tokens are tied to the organization, not to a specific user. This means they cannot be used to invite or delete users, as their scopes do not include permissions at such a high level. A personal authentication token tied to your user role can perform organization member-related actions if your user role is set to Manager or Owner.
 
 ### Self-hosted Sentry
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ It's best practice not to store the authentication token in plain text. As an al
 provider "sentry" {}
 ```
 
+~> **NOTE:** Integration tokens are tied to the organization, not a specific user. Meaning, they cannot be used to invite/delete users, because the scopes do not include permissions at this high of a level. A personal auth token tied to your user role will be able to perform these specific actions if your user is a Manager or Owner is needed for Organization members.
+
 ### Self-hosted Sentry
 
 If you are self-hosting Sentry, you can set the base URL here. The URL format must be in the format `https://[hostname]/api/`.

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -1,4 +1,7 @@
 ---
+# Generated from templates/index.md.tmpl
+# DO NOT EDIT DIRECTLY
+
 page_title: "Official Sentry Terraform Provider"
 description: |-
   Set up Sentry Team, Projects, Alerts, and more. This provider is maintained with [Sentry.io](https://sentry.io)'s sponsorship. Please add any bug reports/feature requests in the GitHub repo.
@@ -27,6 +30,8 @@ It's best practice not to store the authentication token in plain text. As an al
 ```terraform
 provider "sentry" {}
 ```
+
+**NOTE:** Integration tokens are tied to the organization, not to a specific user. This means they cannot be used to invite or delete users, as their scopes do not include permissions at such a high level. A personal authentication token tied to your user role can perform organization member-related actions if your user role is set to Manager or Owner.
 
 ### Self-hosted Sentry
 


### PR DESCRIPTION
### What

This PR adds a `NOTE` section in the Authentication section to inform about the user token that is required to have in order to manage Organization's members. This came out after receiving the response from the support to my question on managing organization's members.

### Links

- https://sentry.zendesk.com/hc/en-us/articles/27816731570331-How-can-I-change-the-scope-for-an-Organization-Auth-Token
- https://docs.sentry.io/api/auth/#auth-tokens