### PR TITLE
doc: add missing backtick in key datasource

### DIFF
--- a/docs/data-sources/key.md
+++ b/docs/data-sources/key.md
@@ -57,7 +57,7 @@ data "sentry_key" "first" {
 - `dsn` (Map of String) This is a map of DSN values. The keys include `public`, `secret`, `csp`, `security`, `minidump`, `nel`, `unreal`, `cdn`, and `crons`.
 - `dsn_csp` (String, Deprecated) Security header endpoint for features like CSP and Expect-CT reports. **Deprecated** Use `dsn["csp"]` instead.
 - `dsn_public` (String, Deprecated) The DSN tells the SDK where to send the events to. **Deprecated** Use `dsn["public"]` instead.
-- `dsn_secret` (String, Deprecated) Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language. **Deprecated** Use `dsn["secret"] instead.
+- `dsn_secret` (String, Deprecated) Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language. **Deprecated** Use `dsn["secret"]` instead.
 - `javascript_loader_script` (Attributes) The JavaScript loader script configuration. (see [below for nested schema](#nestedatt--javascript_loader_script))
 - `project_id` (String) The ID of the project that the key belongs to.
 - `public` (String) The public key.

--- a/internal/provider/data_source_client_key.go
+++ b/internal/provider/data_source_client_key.go
@@ -178,7 +178,7 @@ func (d *ClientKeyDataSource) Schema(ctx context.Context, req datasource.SchemaR
 				Computed:            true,
 			},
 			"dsn_secret": schema.StringAttribute{
-				MarkdownDescription: "Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language. **Deprecated** Use `dsn[\"secret\"] instead.",
+				MarkdownDescription: "Deprecated DSN includes a secret which is no longer required by newer SDK versions. If you are unsure which to use, follow installation instructions for your language. **Deprecated** Use `dsn[\"secret\"]` instead.",
 				DeprecationMessage:  "This field is deprecated and will be removed in a future version. Use `dsn[\"secret\"]` instead.",
 				Computed:            true,
 			},


### PR DESCRIPTION
Found this missing backtick that causes the inline code block to not properly display.