### PR TITLE
feat: add admin role of org

### DIFF
--- a/sentry/resource_sentry_organization_member.go
+++ b/sentry/resource_sentry_organization_member.go
@@ -48,6 +48,7 @@ func resourceSentryOrganizationMember() *schema.Resource {
 					[]string{
 						"billing",
 						"member",
+						"admin",
 						"manager",
 						"owner",
 					},


### PR DESCRIPTION
which is valid in Sentry no matter it's self-hosted or Saas.