### PR TITLE
fix: `0` values in `conditions_v2`

### DIFF
--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -670,7 +670,7 @@ paths:
                 conditions:
                   type: array
                   items:
-                    $ref: "#/components/schemas/ProjectRuleCondition"
+                    $ref: "#/components/schemas/ProjectRuleConditionToApi"
                 filters:
                   type: array
                   items:
@@ -767,7 +767,7 @@ paths:
                 conditions:
                   type: array
                   items:
-                    $ref: "#/components/schemas/ProjectRuleCondition"
+                    $ref: "#/components/schemas/ProjectRuleConditionToApi"
                 filters:
                   type: array
                   items:
@@ -1327,6 +1327,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ProjectRuleAction"
+
+    # There is arguably a bug in the Sentry API where integer values of 0 will
+    # be stripped from submitted payload objects because of Python's implicit
+    # bool conversions. These values can successfully be submitted as strings.
+    # When these objects are retrieved from the API, the values are integers.
+    # To model this, we have two different schemas for rule conditions based
+    # based on whether we're sending them to the API or retriving them from
+    # the API: ProjectRuleCondition and ProjectRuleConditionToApi.
     ProjectRuleCondition:
       oneOf:
         - $ref: "#/components/schemas/ProjectRuleConditionFirstSeenEvent"
@@ -1348,6 +1356,28 @@ components:
           "sentry.rules.conditions.event_frequency.EventFrequencyCondition": "#/components/schemas/ProjectRuleConditionEventFrequency"
           "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition": "#/components/schemas/ProjectRuleConditionEventUniqueUserFrequency"
           "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition": "#/components/schemas/ProjectRuleConditionEventFrequencyPercent"
+
+    ProjectRuleConditionToApi:
+      oneOf:
+        - $ref: "#/components/schemas/ProjectRuleConditionFirstSeenEvent"
+        - $ref: "#/components/schemas/ProjectRuleConditionRegressionEvent"
+        - $ref: "#/components/schemas/ProjectRuleConditionReappearedEvent"
+        - $ref: "#/components/schemas/ProjectRuleConditionNewHighPriorityIssue"
+        - $ref: "#/components/schemas/ProjectRuleConditionExistingHighPriorityIssue"
+        - $ref: "#/components/schemas/ProjectRuleConditionEventFrequencyToApi"
+        - $ref: "#/components/schemas/ProjectRuleConditionEventUniqueUserFrequencyToApi"
+        - $ref: "#/components/schemas/ProjectRuleConditionEventFrequencyPercentToApi"
+      discriminator:
+        propertyName: id
+        mapping:
+          "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition": "#/components/schemas/ProjectRuleConditionFirstSeenEvent"
+          "sentry.rules.conditions.regression_event.RegressionEventCondition": "#/components/schemas/ProjectRuleConditionRegressionEvent"
+          "sentry.rules.conditions.reappeared_event.ReappearedEventCondition": "#/components/schemas/ProjectRuleConditionReappearedEvent"
+          "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition": "#/components/schemas/ProjectRuleConditionNewHighPriorityIssue"
+          "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition": "#/components/schemas/ProjectRuleConditionExistingHighPriorityIssue"
+          "sentry.rules.conditions.event_frequency.EventFrequencyCondition": "#/components/schemas/ProjectRuleConditionEventFrequencyToApi"
+          "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition": "#/components/schemas/ProjectRuleConditionEventUniqueUserFrequencyToApi"
+          "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition": "#/components/schemas/ProjectRuleConditionEventFrequencyPercentToApi"
     ProjectRuleConditionFirstSeenEvent:
       type: object
       required:
@@ -1426,6 +1456,28 @@ components:
           format: int64
         interval:
           type: string
+    ProjectRuleConditionEventFrequencyToApi:
+      type: object
+      required:
+        - id
+        - comparisonType
+        - value
+        - interval
+      properties:
+        id:
+          type: string
+          enum:
+            - "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
+        name:
+          type: string
+        comparisonType:
+          type: string
+        comparisonInterval:
+          type: string
+        value:
+          type: string
+        interval:
+          type: string
     ProjectRuleConditionEventUniqueUserFrequency:
       type: object
       required:
@@ -1449,6 +1501,28 @@ components:
           format: int64
         interval:
           type: string
+    ProjectRuleConditionEventUniqueUserFrequencyToApi:
+      type: object
+      required:
+        - id
+        - comparisonType
+        - value
+        - interval
+      properties:
+        id:
+          type: string
+          enum:
+            - "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
+        name:
+          type: string
+        comparisonType:
+          type: string
+        comparisonInterval:
+          type: string
+        value:
+          type: string
+        interval:
+          type: string
     ProjectRuleConditionEventFrequencyPercent:
       type: object
       required:
@@ -1470,6 +1544,28 @@ components:
         value:
           type: number
           format: double
+        interval:
+          type: string
+    ProjectRuleConditionEventFrequencyPercentToApi:
+      type: object
+      required:
+        - id
+        - comparisonType
+        - value
+        - interval
+      properties:
+        id:
+          type: string
+          enum:
+            - "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
+        name:
+          type: string
+        comparisonType:
+          type: string
+        comparisonInterval:
+          type: string
+        value:
+          type: string
         interval:
           type: string
     ProjectRuleFilter:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -104,17 +104,32 @@ const (
 
 // Defines values for ProjectRuleConditionEventFrequencyId.
 const (
-	SentryRulesConditionsEventFrequencyEventFrequencyCondition ProjectRuleConditionEventFrequencyId = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
+	ProjectRuleConditionEventFrequencyIdSentryRulesConditionsEventFrequencyEventFrequencyCondition ProjectRuleConditionEventFrequencyId = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
 )
 
 // Defines values for ProjectRuleConditionEventFrequencyPercentId.
 const (
-	SentryRulesConditionsEventFrequencyEventFrequencyPercentCondition ProjectRuleConditionEventFrequencyPercentId = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
+	ProjectRuleConditionEventFrequencyPercentIdSentryRulesConditionsEventFrequencyEventFrequencyPercentCondition ProjectRuleConditionEventFrequencyPercentId = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
+)
+
+// Defines values for ProjectRuleConditionEventFrequencyPercentToApiId.
+const (
+	ProjectRuleConditionEventFrequencyPercentToApiIdSentryRulesConditionsEventFrequencyEventFrequencyPercentCondition ProjectRuleConditionEventFrequencyPercentToApiId = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
+)
+
+// Defines values for ProjectRuleConditionEventFrequencyToApiId.
+const (
+	ProjectRuleConditionEventFrequencyToApiIdSentryRulesConditionsEventFrequencyEventFrequencyCondition ProjectRuleConditionEventFrequencyToApiId = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
 )
 
 // Defines values for ProjectRuleConditionEventUniqueUserFrequencyId.
 const (
-	SentryRulesConditionsEventFrequencyEventUniqueUserFrequencyCondition ProjectRuleConditionEventUniqueUserFrequencyId = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
+	ProjectRuleConditionEventUniqueUserFrequencyIdSentryRulesConditionsEventFrequencyEventUniqueUserFrequencyCondition ProjectRuleConditionEventUniqueUserFrequencyId = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
+)
+
+// Defines values for ProjectRuleConditionEventUniqueUserFrequencyToApiId.
+const (
+	ProjectRuleConditionEventUniqueUserFrequencyToApiIdSentryRulesConditionsEventFrequencyEventUniqueUserFrequencyCondition ProjectRuleConditionEventUniqueUserFrequencyToApiId = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
 )
 
 // Defines values for ProjectRuleConditionExistingHighPriorityIssueId.
@@ -603,6 +618,32 @@ type ProjectRuleConditionEventFrequencyPercent struct {
 // ProjectRuleConditionEventFrequencyPercentId defines model for ProjectRuleConditionEventFrequencyPercent.Id.
 type ProjectRuleConditionEventFrequencyPercentId string
 
+// ProjectRuleConditionEventFrequencyPercentToApi defines model for ProjectRuleConditionEventFrequencyPercentToApi.
+type ProjectRuleConditionEventFrequencyPercentToApi struct {
+	ComparisonInterval *string                                          `json:"comparisonInterval,omitempty"`
+	ComparisonType     string                                           `json:"comparisonType"`
+	Id                 ProjectRuleConditionEventFrequencyPercentToApiId `json:"id"`
+	Interval           string                                           `json:"interval"`
+	Name               *string                                          `json:"name,omitempty"`
+	Value              string                                           `json:"value"`
+}
+
+// ProjectRuleConditionEventFrequencyPercentToApiId defines model for ProjectRuleConditionEventFrequencyPercentToApi.Id.
+type ProjectRuleConditionEventFrequencyPercentToApiId string
+
+// ProjectRuleConditionEventFrequencyToApi defines model for ProjectRuleConditionEventFrequencyToApi.
+type ProjectRuleConditionEventFrequencyToApi struct {
+	ComparisonInterval *string                                   `json:"comparisonInterval,omitempty"`
+	ComparisonType     string                                    `json:"comparisonType"`
+	Id                 ProjectRuleConditionEventFrequencyToApiId `json:"id"`
+	Interval           string                                    `json:"interval"`
+	Name               *string                                   `json:"name,omitempty"`
+	Value              string                                    `json:"value"`
+}
+
+// ProjectRuleConditionEventFrequencyToApiId defines model for ProjectRuleConditionEventFrequencyToApi.Id.
+type ProjectRuleConditionEventFrequencyToApiId string
+
 // ProjectRuleConditionEventUniqueUserFrequency defines model for ProjectRuleConditionEventUniqueUserFrequency.
 type ProjectRuleConditionEventUniqueUserFrequency struct {
 	ComparisonInterval *string                                        `json:"comparisonInterval,omitempty"`
@@ -615,6 +656,19 @@ type ProjectRuleConditionEventUniqueUserFrequency struct {
 
 // ProjectRuleConditionEventUniqueUserFrequencyId defines model for ProjectRuleConditionEventUniqueUserFrequency.Id.
 type ProjectRuleConditionEventUniqueUserFrequencyId string
+
+// ProjectRuleConditionEventUniqueUserFrequencyToApi defines model for ProjectRuleConditionEventUniqueUserFrequencyToApi.
+type ProjectRuleConditionEventUniqueUserFrequencyToApi struct {
+	ComparisonInterval *string                                             `json:"comparisonInterval,omitempty"`
+	ComparisonType     string                                              `json:"comparisonType"`
+	Id                 ProjectRuleConditionEventUniqueUserFrequencyToApiId `json:"id"`
+	Interval           string                                              `json:"interval"`
+	Name               *string                                             `json:"name,omitempty"`
+	Value              string                                              `json:"value"`
+}
+
+// ProjectRuleConditionEventUniqueUserFrequencyToApiId defines model for ProjectRuleConditionEventUniqueUserFrequencyToApi.Id.
+type ProjectRuleConditionEventUniqueUserFrequencyToApiId string
 
 // ProjectRuleConditionExistingHighPriorityIssue defines model for ProjectRuleConditionExistingHighPriorityIssue.
 type ProjectRuleConditionExistingHighPriorityIssue struct {
@@ -660,6 +714,11 @@ type ProjectRuleConditionRegressionEvent struct {
 
 // ProjectRuleConditionRegressionEventId defines model for ProjectRuleConditionRegressionEvent.Id.
 type ProjectRuleConditionRegressionEventId string
+
+// ProjectRuleConditionToApi defines model for ProjectRuleConditionToApi.
+type ProjectRuleConditionToApi struct {
+	union json.RawMessage
+}
 
 // ProjectRuleFilter defines model for ProjectRuleFilter.
 type ProjectRuleFilter struct {
@@ -922,30 +981,30 @@ type UpdateProjectClientKeyJSONBody struct {
 
 // CreateProjectRuleJSONBody defines parameters for CreateProjectRule.
 type CreateProjectRuleJSONBody struct {
-	ActionMatch string                 `json:"actionMatch"`
-	Actions     []ProjectRuleAction    `json:"actions"`
-	Conditions  []ProjectRuleCondition `json:"conditions"`
-	Environment *string                `json:"environment,omitempty"`
-	FilterMatch string                 `json:"filterMatch"`
-	Filters     []ProjectRuleFilter    `json:"filters"`
-	Frequency   int64                  `json:"frequency"`
-	Name        string                 `json:"name"`
-	Owner       *string                `json:"owner,omitempty"`
-	Projects    []string               `json:"projects"`
+	ActionMatch string                      `json:"actionMatch"`
+	Actions     []ProjectRuleAction         `json:"actions"`
+	Conditions  []ProjectRuleConditionToApi `json:"conditions"`
+	Environment *string                     `json:"environment,omitempty"`
+	FilterMatch string                      `json:"filterMatch"`
+	Filters     []ProjectRuleFilter         `json:"filters"`
+	Frequency   int64                       `json:"frequency"`
+	Name        string                      `json:"name"`
+	Owner       *string                     `json:"owner,omitempty"`
+	Projects    []string                    `json:"projects"`
 }
 
 // UpdateProjectRuleJSONBody defines parameters for UpdateProjectRule.
 type UpdateProjectRuleJSONBody struct {
-	ActionMatch string                 `json:"actionMatch"`
-	Actions     []ProjectRuleAction    `json:"actions"`
-	Conditions  []ProjectRuleCondition `json:"conditions"`
-	Environment *string                `json:"environment,omitempty"`
-	FilterMatch string                 `json:"filterMatch"`
-	Filters     []ProjectRuleFilter    `json:"filters"`
-	Frequency   int64                  `json:"frequency"`
-	Name        string                 `json:"name"`
-	Owner       *string                `json:"owner,omitempty"`
-	Projects    []string               `json:"projects"`
+	ActionMatch string                      `json:"actionMatch"`
+	Actions     []ProjectRuleAction         `json:"actions"`
+	Conditions  []ProjectRuleConditionToApi `json:"conditions"`
+	Environment *string                     `json:"environment,omitempty"`
+	FilterMatch string                      `json:"filterMatch"`
+	Filters     []ProjectRuleFilter         `json:"filters"`
+	Frequency   int64                       `json:"frequency"`
+	Name        string                      `json:"name"`
+	Owner       *string                     `json:"owner,omitempty"`
+	Projects    []string                    `json:"projects"`
 }
 
 // CreateOrganizationTeamProjectJSONBody defines parameters for CreateOrganizationTeamProject.
@@ -2004,6 +2063,275 @@ func (t ProjectRuleCondition) MarshalJSON() ([]byte, error) {
 }
 
 func (t *ProjectRuleCondition) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsProjectRuleConditionFirstSeenEvent returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionFirstSeenEvent
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionFirstSeenEvent() (ProjectRuleConditionFirstSeenEvent, error) {
+	var body ProjectRuleConditionFirstSeenEvent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionFirstSeenEvent overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionFirstSeenEvent
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionFirstSeenEvent(v ProjectRuleConditionFirstSeenEvent) error {
+	v.Id = "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionFirstSeenEvent performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionFirstSeenEvent
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionFirstSeenEvent(v ProjectRuleConditionFirstSeenEvent) error {
+	v.Id = "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionRegressionEvent returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionRegressionEvent
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionRegressionEvent() (ProjectRuleConditionRegressionEvent, error) {
+	var body ProjectRuleConditionRegressionEvent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionRegressionEvent overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionRegressionEvent
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionRegressionEvent(v ProjectRuleConditionRegressionEvent) error {
+	v.Id = "sentry.rules.conditions.regression_event.RegressionEventCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionRegressionEvent performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionRegressionEvent
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionRegressionEvent(v ProjectRuleConditionRegressionEvent) error {
+	v.Id = "sentry.rules.conditions.regression_event.RegressionEventCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionReappearedEvent returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionReappearedEvent
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionReappearedEvent() (ProjectRuleConditionReappearedEvent, error) {
+	var body ProjectRuleConditionReappearedEvent
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionReappearedEvent overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionReappearedEvent
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionReappearedEvent(v ProjectRuleConditionReappearedEvent) error {
+	v.Id = "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionReappearedEvent performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionReappearedEvent
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionReappearedEvent(v ProjectRuleConditionReappearedEvent) error {
+	v.Id = "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionNewHighPriorityIssue returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionNewHighPriorityIssue
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionNewHighPriorityIssue() (ProjectRuleConditionNewHighPriorityIssue, error) {
+	var body ProjectRuleConditionNewHighPriorityIssue
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionNewHighPriorityIssue overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionNewHighPriorityIssue
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionNewHighPriorityIssue(v ProjectRuleConditionNewHighPriorityIssue) error {
+	v.Id = "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionNewHighPriorityIssue performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionNewHighPriorityIssue
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionNewHighPriorityIssue(v ProjectRuleConditionNewHighPriorityIssue) error {
+	v.Id = "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionExistingHighPriorityIssue returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionExistingHighPriorityIssue
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionExistingHighPriorityIssue() (ProjectRuleConditionExistingHighPriorityIssue, error) {
+	var body ProjectRuleConditionExistingHighPriorityIssue
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionExistingHighPriorityIssue overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionExistingHighPriorityIssue
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionExistingHighPriorityIssue(v ProjectRuleConditionExistingHighPriorityIssue) error {
+	v.Id = "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionExistingHighPriorityIssue performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionExistingHighPriorityIssue
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionExistingHighPriorityIssue(v ProjectRuleConditionExistingHighPriorityIssue) error {
+	v.Id = "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionEventFrequencyToApi returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionEventFrequencyToApi
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionEventFrequencyToApi() (ProjectRuleConditionEventFrequencyToApi, error) {
+	var body ProjectRuleConditionEventFrequencyToApi
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionEventFrequencyToApi overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionEventFrequencyToApi
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionEventFrequencyToApi(v ProjectRuleConditionEventFrequencyToApi) error {
+	v.Id = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionEventFrequencyToApi performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionEventFrequencyToApi
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionEventFrequencyToApi(v ProjectRuleConditionEventFrequencyToApi) error {
+	v.Id = "sentry.rules.conditions.event_frequency.EventFrequencyCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionEventUniqueUserFrequencyToApi returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionEventUniqueUserFrequencyToApi
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionEventUniqueUserFrequencyToApi() (ProjectRuleConditionEventUniqueUserFrequencyToApi, error) {
+	var body ProjectRuleConditionEventUniqueUserFrequencyToApi
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionEventUniqueUserFrequencyToApi overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionEventUniqueUserFrequencyToApi
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionEventUniqueUserFrequencyToApi(v ProjectRuleConditionEventUniqueUserFrequencyToApi) error {
+	v.Id = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionEventUniqueUserFrequencyToApi performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionEventUniqueUserFrequencyToApi
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionEventUniqueUserFrequencyToApi(v ProjectRuleConditionEventUniqueUserFrequencyToApi) error {
+	v.Id = "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsProjectRuleConditionEventFrequencyPercentToApi returns the union data inside the ProjectRuleConditionToApi as a ProjectRuleConditionEventFrequencyPercentToApi
+func (t ProjectRuleConditionToApi) AsProjectRuleConditionEventFrequencyPercentToApi() (ProjectRuleConditionEventFrequencyPercentToApi, error) {
+	var body ProjectRuleConditionEventFrequencyPercentToApi
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromProjectRuleConditionEventFrequencyPercentToApi overwrites any union data inside the ProjectRuleConditionToApi as the provided ProjectRuleConditionEventFrequencyPercentToApi
+func (t *ProjectRuleConditionToApi) FromProjectRuleConditionEventFrequencyPercentToApi(v ProjectRuleConditionEventFrequencyPercentToApi) error {
+	v.Id = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeProjectRuleConditionEventFrequencyPercentToApi performs a merge with any union data inside the ProjectRuleConditionToApi, using the provided ProjectRuleConditionEventFrequencyPercentToApi
+func (t *ProjectRuleConditionToApi) MergeProjectRuleConditionEventFrequencyPercentToApi(v ProjectRuleConditionEventFrequencyPercentToApi) error {
+	v.Id = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t ProjectRuleConditionToApi) Discriminator() (string, error) {
+	var discriminator struct {
+		Discriminator string `json:"id"`
+	}
+	err := json.Unmarshal(t.union, &discriminator)
+	return discriminator.Discriminator, err
+}
+
+func (t ProjectRuleConditionToApi) ValueByDiscriminator() (interface{}, error) {
+	discriminator, err := t.Discriminator()
+	if err != nil {
+		return nil, err
+	}
+	switch discriminator {
+	case "sentry.rules.conditions.event_frequency.EventFrequencyCondition":
+		return t.AsProjectRuleConditionEventFrequencyToApi()
+	case "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition":
+		return t.AsProjectRuleConditionEventFrequencyPercentToApi()
+	case "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition":
+		return t.AsProjectRuleConditionEventUniqueUserFrequencyToApi()
+	case "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition":
+		return t.AsProjectRuleConditionFirstSeenEvent()
+	case "sentry.rules.conditions.high_priority_issue.ExistingHighPriorityIssueCondition":
+		return t.AsProjectRuleConditionExistingHighPriorityIssue()
+	case "sentry.rules.conditions.high_priority_issue.NewHighPriorityIssueCondition":
+		return t.AsProjectRuleConditionNewHighPriorityIssue()
+	case "sentry.rules.conditions.reappeared_event.ReappearedEventCondition":
+		return t.AsProjectRuleConditionReappearedEvent()
+	case "sentry.rules.conditions.regression_event.RegressionEventCondition":
+		return t.AsProjectRuleConditionRegressionEvent()
+	default:
+		return nil, errors.New("unknown discriminator value: " + discriminator)
+	}
+}
+
+func (t ProjectRuleConditionToApi) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *ProjectRuleConditionToApi) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -27,9 +28,9 @@ func (m *IssueAlertConditionFirstSeenEventModel) Fill(ctx context.Context, condi
 	return
 }
 
-func (m IssueAlertConditionFirstSeenEventModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionFirstSeenEventModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
+	var v apiclient.ProjectRuleConditionToApi
 	err := v.FromProjectRuleConditionFirstSeenEvent(apiclient.ProjectRuleConditionFirstSeenEvent{
 		Name: m.Name.ValueStringPointer(),
 	})
@@ -49,9 +50,9 @@ func (m *IssueAlertConditionRegressionEventModel) Fill(ctx context.Context, cond
 	return
 }
 
-func (m IssueAlertConditionRegressionEventModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionRegressionEventModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
+	var v apiclient.ProjectRuleConditionToApi
 	err := v.FromProjectRuleConditionRegressionEvent(apiclient.ProjectRuleConditionRegressionEvent{
 		Name: m.Name.ValueStringPointer(),
 	})
@@ -71,9 +72,9 @@ func (m *IssueAlertConditionReappearedEventModel) Fill(ctx context.Context, cond
 	return
 }
 
-func (m IssueAlertConditionReappearedEventModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionReappearedEventModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
+	var v apiclient.ProjectRuleConditionToApi
 	err := v.FromProjectRuleConditionReappearedEvent(apiclient.ProjectRuleConditionReappearedEvent{
 		Name: m.Name.ValueStringPointer(),
 	})
@@ -93,9 +94,9 @@ func (m *IssueAlertConditionNewHighPriorityIssueModel) Fill(ctx context.Context,
 	return
 }
 
-func (m IssueAlertConditionNewHighPriorityIssueModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionNewHighPriorityIssueModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
+	var v apiclient.ProjectRuleConditionToApi
 	err := v.FromProjectRuleConditionNewHighPriorityIssue(apiclient.ProjectRuleConditionNewHighPriorityIssue{
 		Name: m.Name.ValueStringPointer(),
 	})
@@ -115,9 +116,9 @@ func (m *IssueAlertConditionExistingHighPriorityIssueModel) Fill(ctx context.Con
 	return
 }
 
-func (m IssueAlertConditionExistingHighPriorityIssueModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionExistingHighPriorityIssueModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
+	var v apiclient.ProjectRuleConditionToApi
 	err := v.FromProjectRuleConditionExistingHighPriorityIssue(apiclient.ProjectRuleConditionExistingHighPriorityIssue{
 		Name: m.Name.ValueStringPointer(),
 	})
@@ -145,14 +146,15 @@ func (m *IssueAlertConditionEventFrequencyModel) Fill(ctx context.Context, condi
 	return
 }
 
-func (m IssueAlertConditionEventFrequencyModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionEventFrequencyModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
-	err := v.FromProjectRuleConditionEventFrequency(apiclient.ProjectRuleConditionEventFrequency{
+	var v apiclient.ProjectRuleConditionToApi
+	value := strconv.FormatInt(m.Value.ValueInt64(), 10)
+	err := v.FromProjectRuleConditionEventFrequencyToApi(apiclient.ProjectRuleConditionEventFrequencyToApi{
 		Name:               m.Name.ValueStringPointer(),
 		ComparisonType:     m.ComparisonType.ValueString(),
 		ComparisonInterval: m.ComparisonInterval.ValueStringPointer(),
-		Value:              m.Value.ValueInt64(),
+		Value:              value,
 		Interval:           m.Interval.ValueString(),
 	})
 	if err != nil {
@@ -179,14 +181,14 @@ func (m *IssueAlertConditionEventUniqueUserFrequencyModel) Fill(ctx context.Cont
 	return
 }
 
-func (m IssueAlertConditionEventUniqueUserFrequencyModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionEventUniqueUserFrequencyModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
-	err := v.FromProjectRuleConditionEventUniqueUserFrequency(apiclient.ProjectRuleConditionEventUniqueUserFrequency{
+	var v apiclient.ProjectRuleConditionToApi
+	err := v.FromProjectRuleConditionEventUniqueUserFrequencyToApi(apiclient.ProjectRuleConditionEventUniqueUserFrequencyToApi{
 		Name:               m.Name.ValueStringPointer(),
 		ComparisonType:     m.ComparisonType.ValueString(),
 		ComparisonInterval: m.ComparisonInterval.ValueStringPointer(),
-		Value:              m.Value.ValueInt64(),
+		Value:              strconv.FormatInt(m.Value.ValueInt64(), 10),
 		Interval:           m.Interval.ValueString(),
 	})
 	if err != nil {
@@ -213,14 +215,14 @@ func (m *IssueAlertConditionEventFrequencyPercentModel) Fill(ctx context.Context
 	return
 }
 
-func (m IssueAlertConditionEventFrequencyPercentModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionEventFrequencyPercentModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	var diags diag.Diagnostics
-	var v apiclient.ProjectRuleCondition
-	err := v.FromProjectRuleConditionEventFrequencyPercent(apiclient.ProjectRuleConditionEventFrequencyPercent{
+	var v apiclient.ProjectRuleConditionToApi
+	err := v.FromProjectRuleConditionEventFrequencyPercentToApi(apiclient.ProjectRuleConditionEventFrequencyPercentToApi{
 		Name:               m.Name.ValueStringPointer(),
 		ComparisonType:     m.ComparisonType.ValueString(),
 		ComparisonInterval: m.ComparisonInterval.ValueStringPointer(),
-		Value:              m.Value.ValueFloat64(),
+		Value:              strconv.FormatFloat(m.Value.ValueFloat64(), 'f', -1, 64),
 		Interval:           m.Interval.ValueString(),
 	})
 	if err != nil {
@@ -241,7 +243,7 @@ type IssueAlertConditionModel struct {
 	EventFrequencyPercent     *IssueAlertConditionEventFrequencyPercentModel     `tfsdk:"event_frequency_percent"`
 }
 
-func (m IssueAlertConditionModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleCondition, diag.Diagnostics) {
+func (m IssueAlertConditionModel) ToApi(ctx context.Context) (*apiclient.ProjectRuleConditionToApi, diag.Diagnostics) {
 	if m.FirstSeenEvent != nil {
 		return m.FirstSeenEvent.ToApi(ctx)
 	} else if m.RegressionEvent != nil {

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -712,7 +712,7 @@ func (r *IssueAlertResource) Create(ctx context.Context, req resource.CreateRequ
 	if !data.Conditions.IsNull() {
 		resp.Diagnostics.Append(data.Conditions.Unmarshal(&body.Conditions)...)
 	} else if data.ConditionsV2 != nil {
-		body.Conditions = []apiclient.ProjectRuleCondition{}
+		body.Conditions = []apiclient.ProjectRuleConditionToApi{}
 		for i, item := range *data.ConditionsV2 {
 			condition, diags := item.ToApi(ctx)
 			if diags.HasError() {
@@ -726,7 +726,7 @@ func (r *IssueAlertResource) Create(ctx context.Context, req resource.CreateRequ
 			body.Conditions = append(body.Conditions, *condition)
 		}
 	} else {
-		body.Conditions = []apiclient.ProjectRuleCondition{}
+		body.Conditions = []apiclient.ProjectRuleConditionToApi{}
 	}
 
 	if !data.Filters.IsNull() {
@@ -850,7 +850,7 @@ func (r *IssueAlertResource) Update(ctx context.Context, req resource.UpdateRequ
 	if !data.Conditions.IsNull() {
 		resp.Diagnostics.Append(data.Conditions.Unmarshal(&body.Conditions)...)
 	} else if data.ConditionsV2 != nil {
-		body.Conditions = []apiclient.ProjectRuleCondition{}
+		body.Conditions = []apiclient.ProjectRuleConditionToApi{}
 		for i, item := range *data.ConditionsV2 {
 			condition, diags := item.ToApi(ctx)
 			if diags.HasError() {
@@ -864,7 +864,7 @@ func (r *IssueAlertResource) Update(ctx context.Context, req resource.UpdateRequ
 			body.Conditions = append(body.Conditions, *condition)
 		}
 	} else {
-		body.Conditions = []apiclient.ProjectRuleCondition{}
+		body.Conditions = []apiclient.ProjectRuleConditionToApi{}
 	}
 
 	if !data.Filters.IsNull() {

--- a/internal/sentrydata/sentrydata.go
+++ b/internal/sentrydata/sentrydata.go
@@ -184,7 +184,7 @@ var DashboardWidgetDisplayTypes = []string{
 	"top_n",
 }
 
-// https://github.com/getsentry/sentry/blob/master/src/sentry/models/project.py#L64-L169
+// https://github.com/getsentry/sentry/blob/master/src/sentry/models/project.py#L65-L170
 var Platforms = []string{
 	"other",
 	"android",


### PR DESCRIPTION
There is [arguably a bug in the Sentry API](https://github.com/getsentry/sentry/issues/89042) where integer values of `0` will be stripped from submitted payload objects because of Python's implicit bool conversions. These values can successfully be submitted as strings. When these objects are retrieved from the API, the values are integers.

To model this, we have two different schemas in the OpenAPI spec yaml for rule conditions based based on whether we're sending them to the API or retriving them from the API:
* `ProjectRuleCondition`, which is a set of condition schemas where `value`s are `integers`
* `ProjectRuleConditionToApi` which is a set of condition schemas where `value`s are `string`s

The generated types from these are used in the alert rule resource code in the `Fill` and `ToApi` methods as necessary.

There may be a way to do this without so much duplication, I am definitely open to suggestions!

Fixes #575 