### PR TITLE
Fix auto_assignment attribute documentation

### DIFF
--- a/docs/resources/project_ownership.md
+++ b/docs/resources/project_ownership.md
@@ -17,7 +17,7 @@ Sentry Project Ownership. See the [Sentry documentation](https://docs.sentry.io/
 
 ### Required
 
-- `auto_assignment` (String) The auto-assignment mode. The options are: `none` - No auto-assignment, `all` - Assign all issues, `unhandled` - Assign unhandled issues.
+- `auto_assignment` (String) The auto-assignment mode. The options are: `Auto Assign to Issue Owner`, `Auto Assign to Suspect Commits`, and `Turn off Auto-Assignment`.
 - `codeowners_auto_sync` (Boolean) Whether to automatically sync codeowners.
 - `fallthrough` (Boolean) Whether to fall through to the default ownership rules.
 - `organization` (String) The organization of this resource.

--- a/internal/provider/resource_project_ownership.go
+++ b/internal/provider/resource_project_ownership.go
@@ -71,7 +71,7 @@ func (r *ProjectOwnershipResource) Schema(ctx context.Context, req resource.Sche
 				Required:    true,
 			},
 			"auto_assignment": schema.StringAttribute{
-				Description: "The auto-assignment mode. The options are: `none` - No auto-assignment, `all` - Assign all issues, `unhandled` - Assign unhandled issues.",
+				Description: "The auto-assignment mode. The options are: `Auto Assign to Issue Owner`, `Auto Assign to Suspect Commits`, and `Turn off Auto-Assignment`.",
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf(


### PR DESCRIPTION
For some reason it was incorrectly documented. The options are all strings and can be one of:
* `Auto Assign to Issue Owner`
* `Auto Assign to Suspect Commits`
* `Turn off Auto-Assignment`

FYI @tazorax