### PR TITLE
fix: gracefully handle 404 when sentry team members are removed outside of terraform

### DIFF
--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -239,7 +239,9 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	effectiveRole, err := r.getEffectiveTeamRole(ctx, data.Organization.ValueString(), data.MemberId.ValueString(), data.Team.ValueString())
 	if err != nil {
-		if strings.Contains(err.Error(), "404 The requested resource does not exist") {
+
+		if strings.Contains(err.Error(), "404 The requested resource does not exist") ||
+			strings.Contains(err.Error(), "unable to read organization member, got status code: 404") {
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.Append(diagutils.NewClientError("read", err))


### PR DESCRIPTION
Fixes #654.

It wasn't immediately clear to me if it's still possible for a `404 The requested resource does not exist` error to be thrown so I left it in, but I think it can likely be removed.