### PR TITLE
fix: gracefully handle 404 in issue_alert and project Read methods

### DIFF
--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -813,7 +813,6 @@ func (r *IssueAlertResource) Read(ctx context.Context, req resource.ReadRequest,
 		resp.Diagnostics.Append(diagutils.NewClientError("read", err))
 		return
 	} else if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.Append(diagutils.NewNotFoundError("issue alert"))
 		resp.State.RemoveResource(ctx)
 		return
 	} else if httpResp.StatusCode() != http.StatusOK || httpResp.JSON200 == nil {

--- a/internal/provider/resource_project.go
+++ b/internal/provider/resource_project.go
@@ -643,7 +643,6 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.Append(diagutils.NewClientError("read", err))
 		return
 	} else if httpResp.StatusCode() == http.StatusNotFound {
-		resp.Diagnostics.Append(diagutils.NewNotFoundError("project"))
 		resp.State.RemoveResource(ctx)
 		return
 	} else if httpResp.StatusCode() != http.StatusOK || httpResp.JSON200 == nil {


### PR DESCRIPTION
Currently, this provider handles removal outside of tf for issue_alert and project really bad.
While it tries to remove them from state to generate drift fix plan, it also throws error, which blocks any further plan/apply and requires `terraform state rm` to get out of this step.

**Minimal example to reproduce issue**
```
terraform {
  required_providers {
    sentry = {
      source  = "jianyuan/sentry"
      version = "~> 0.14.5"
    }
  }
}

provider "sentry" {
}

resource "sentry_project" "test_project" {
  organization = "my-org"
  teams        = ["observability"]
  name         = "drift-test-project"
  platform     = "javascript"
}

resource "sentry_issue_alert" "test_alert" {
  organization = "my-org"
  project      = sentry_project.test_project.id
  name         = "drift-test-alert"

  conditions_v2 = [
    { first_seen_event = {} }
  ]

  actions_v2 = [
    {
      notify_email = {
        target_type      = "IssueOwners"
        fallthrough_type = "AllMembers"
      }
    }
  ]

  action_match = "any"
  filter_match = "any"
  frequency    = 30
}
```

Steps to reproduce:
1. Create resources using this tf config.
2. Delete project or alert via Sentry UI
3. Try to do tf plan or apply

**Expected result:**

Provider refresh state, handles 404 properly, and generate plan to fix the drift (create missing resources)

**Actual result:**
Error is thrown, plan/apply operation is not completed, the user is stuck in this state, and needs to manipulate the state.

```
> terraform plan
sentry_project.test_project: Refreshing state... [id=drift-test-project]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Not found
│
│   with sentry_project.test_project,
│   on test-drift.tf line 17, in resource "sentry_project" "test_project":
│   17: resource "sentry_project" "test_project" {
│
│ No matching project found

> terraform apply --auto-approve
sentry_project.test_project: Refreshing state... [id=drift-test-project]
╷
│ Error: Not found
│
│   with sentry_project.test_project,
│   on test-drift.tf line 14, in resource "sentry_project" "test_project":
│   14: resource "sentry_project" "test_project" {
│
│ No matching project found
╵
```

**Solution:**
There is no need to throw this error at all, since provider and tf can handle 404 and drift properly.

Same example with the provider version from this branch

```
> terraform plan
 Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - jianyuan/sentry in /Users/my-username/go/bin
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
╵
sentry_project.test_project: Refreshing state... [id=drift-test-project]
sentry_issue_alert.test_alert: Refreshing state... [id=16132917]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # sentry_project.test_project has been deleted
  - resource "sentry_project" "test_project" {
      - id                = "drift-test-project" -> null
        name              = "drift-test-project"
        # (11 unchanged attributes hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to
these changes.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # sentry_issue_alert.test_alert will be created
  + resource "sentry_issue_alert" "test_alert" {
      + action_match  = "any"
      + actions_v2    = [
          + {
              + notify_email = {
                  + fallthrough_type = "AllMembers"
                  + name             = (known after apply)
                  + target_type      = "IssueOwners"
                }
            },
        ]
      + conditions_v2 = [
          + {
              + first_seen_event = {
                  + name = (known after apply)
                }
            },
        ]
      + filter_match  = "any"
      + frequency     = 30
      + id            = (known after apply)
      + name          = "drift-test-alert"
      + organization  = "my-org"
      + project       = (known after apply)
    }

  # sentry_project.test_project will be created
  + resource "sentry_project" "test_project" {
      + client_security       = (known after apply)
      + digests_max_delay     = (known after apply)
      + digests_min_delay     = (known after apply)
      + features              = (known after apply)
      + filters               = (known after apply)
      + fingerprinting_rules  = (known after apply)
      + grouping_enhancements = (known after apply)
      + id                    = (known after apply)
      + internal_id           = (known after apply)
      + name                  = "drift-test-project"
      + organization          = "my-org"
      + platform              = "javascript"
      + resolve_age           = (known after apply)
      + slug                  = (known after apply)
      + teams                 = [
          + "observability",
        ]
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```