### PR TITLE
fix: extend removed team members error handling

### DIFF
--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -239,9 +239,8 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	effectiveRole, err := r.getEffectiveTeamRole(ctx, data.Organization.ValueString(), data.MemberId.ValueString(), data.Team.ValueString())
 	if err != nil {
-
-		if strings.Contains(err.Error(), "404 The requested resource does not exist") ||
-			strings.Contains(err.Error(), "unable to read organization member, got status code: 404") {
+		memberIsRemoved, _ := regexp.MatchString("unable to read organization member.*got status code: 404", str)
+		if strings.Contains(err.Error(), "404 The requested resource does not exist") || memberIsRemoved {
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.Append(diagutils.NewClientError("read", err))


### PR DESCRIPTION
This change extends the work done by @thomasv314 in #655.

Currently, only `unable to read organization member, got status code: 404` is handled. However, when we run into this issue on our end, the error we receive is:

```
unable to read organization member (organization=my-organisation, member_id=123456), got status code: 404
```

This PR extends the error handling to handle both.