### PR TITLE
fix: handle HTTP 201 Created response for issue alert creation

### DIFF
--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -961,6 +961,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ProjectRule"
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectRule"
         "202":
           description: Accepted
           content:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -10300,6 +10300,7 @@ type CreateProjectRuleResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *ProjectRule
+	JSON201      *ProjectRule
 	JSON202      *struct {
 		Uuid string `json:"uuid"`
 	}
@@ -11801,6 +11802,13 @@ func ParseCreateProjectRuleResponse(rsp *http.Response) (*CreateProjectRuleRespo
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ProjectRule
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 202:
 		var dest struct {

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -838,12 +838,16 @@ func (r *IssueAlertResource) Create(ctx context.Context, req resource.CreateRequ
 	if err != nil {
 		resp.Diagnostics.Append(diagutils.NewClientError("create", err))
 		return
-	} else if httpResp.StatusCode() != http.StatusOK || httpResp.JSON200 == nil {
+	} else if (httpResp.StatusCode() != http.StatusOK && httpResp.StatusCode() != http.StatusCreated) || (httpResp.JSON200 == nil && httpResp.JSON201 == nil) {
 		resp.Diagnostics.Append(diagutils.NewClientStatusError("create", httpResp.StatusCode(), httpResp.Body))
 		return
 	}
 
-	resp.Diagnostics.Append(data.Fill(ctx, *httpResp.JSON200)...)
+	rule := httpResp.JSON200
+	if rule == nil {
+		rule = httpResp.JSON201
+	}
+	resp.Diagnostics.Append(data.Fill(ctx, *rule)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}


### PR DESCRIPTION
## Problem

Sentry's API now returns **HTTP 201 Created** when `POST /api/0/projects/{org}/{project}/rules/` successfully creates an issue alert rule. The provider only handles 200 and 202 responses, causing:

```
Unable to create, got error: json: cannot unmarshal array into Go value of type apiclient.ProjectRule
```

This breaks `sentry_issue_alert` resource creation in v0.15.0-beta1.

## Root Cause

The Sentry backend returns 201 for successful rule creation ([source](https://github.com/getsentry/sentry/blob/master/src/sentry/issues/endpoints/project_rules.py)), but the OpenAPI spec and generated client only define handlers for 200 and 202.

## Changes

1. **`internal/apiclient/api.yaml`** — Added `"201"` response with `ProjectRule` schema to the `createProjectRule` endpoint
2. **`internal/apiclient/apiclient.gen.go`** — Added `JSON201` field to `CreateProjectRuleResponse` struct and 201 case to `ParseCreateProjectRuleResponse` (manually edited to match what `go generate` would produce)
3. **`internal/provider/resource_issue_alert.go`** — Updated Create method to accept both 200 and 201, using whichever response body is populated

## Note

The generated file was edited manually since I didn't have the exact `oapi-codegen` version available locally. Please re-run `go generate ./internal/apiclient/...` to verify the generated output matches.

## Test plan

- [ ] `go generate ./internal/apiclient/...` produces matching output
- [ ] `go test ./internal/provider/...` passes
- [ ] Create a `sentry_issue_alert` resource against a live Sentry org