### PR TITLE
feat: add settings_labels to notify_event_sentry_app action

### DIFF
--- a/docs/data-sources/issue_alert.md
+++ b/docs/data-sources/issue_alert.md
@@ -173,6 +173,7 @@ Read-Only:
 - `name` (String)
 - `sentry_app_installation_uuid` (String)
 - `settings` (Map of String)
+- `settings_labels` (Map of String)
 
 
 <a id="nestedatt--actions_v2--notify_event_service"></a>

--- a/docs/resources/issue_alert.md
+++ b/docs/resources/issue_alert.md
@@ -690,6 +690,7 @@ Required:
 Optional:
 
 - `settings` (Map of String)
+- `settings_labels` (Map of String) Optional display labels for each settings entry, keyed by setting name. When present, the label is sent to the API so Sentry's frontend can render the correct display name for async-select fields.
 
 Read-Only:
 

--- a/docs/resources/issue_alert.md
+++ b/docs/resources/issue_alert.md
@@ -690,7 +690,7 @@ Required:
 Optional:
 
 - `settings` (Map of String)
-- `settings_labels` (Map of String) Optional display labels for each settings entry, keyed by setting name. When present, the label is sent to the API so Sentry's frontend can render the correct display name for async-select fields.
+- `settings_labels` (Map of String) Optional mapping of setting keys to human-readable display labels. This is primarily used for `async-select` fields in the Sentry UI.
 
 Read-Only:
 

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -2127,6 +2127,8 @@ components:
                 type: string
               value:
                 type: string
+              label:
+                type: string
     ProjectRuleActionOpsgenieNotifyTeam:
       type: object
       required:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -2622,8 +2622,9 @@ type ProjectRuleActionNotifyEventSentryApp struct {
 	Name                      *string                                 `json:"name,omitempty"`
 	SentryAppInstallationUuid string                                  `json:"sentryAppInstallationUuid"`
 	Settings                  *[]struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
+		Label *string `json:"label,omitempty"`
+		Name  string  `json:"name"`
+		Value string  `json:"value"`
 	} `json:"settings,omitempty"`
 	Uuid *string `json:"uuid,omitempty"`
 }

--- a/internal/provider/data_source_issue_alert.go
+++ b/internal/provider/data_source_issue_alert.go
@@ -293,8 +293,12 @@ func (d *IssueAlertDataSource) Schema(ctx context.Context, req datasource.Schema
 								"name":                         stringAttribute,
 								"sentry_app_installation_uuid": stringAttribute,
 								"settings": schema.MapAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
+									Computed:   true,
+									CustomType: supertypes.NewMapTypeOf[string](ctx),
+								},
+								"settings_labels": schema.MapAttribute{
+									Computed:   true,
+									CustomType: supertypes.NewMapTypeOf[string](ctx),
 								},
 							},
 						},

--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -876,6 +876,7 @@ type IssueAlertActionNotifyEventSentryAppModel struct {
 	Name                      types.String                  `tfsdk:"name"`
 	SentryAppInstallationUuid types.String                  `tfsdk:"sentry_app_installation_uuid"`
 	Settings                  supertypes.MapValueOf[string] `tfsdk:"settings"`
+	SettingsLabels            supertypes.MapValueOf[string] `tfsdk:"settings_labels"`
 }
 
 func (m *IssueAlertActionNotifyEventSentryAppModel) Fill(ctx context.Context, action apiclient.ProjectRuleActionNotifyEventSentryApp) (diags diag.Diagnostics) {
@@ -886,10 +887,15 @@ func (m *IssueAlertActionNotifyEventSentryAppModel) Fill(ctx context.Context, ac
 		m.Settings = supertypes.NewMapValueOfNull[string](ctx)
 	} else {
 		var settingsMap = make(map[string]string, len(*action.Settings))
+		var labelsMap = make(map[string]string, len(*action.Settings))
 		for _, setting := range *action.Settings {
 			settingsMap[setting.Name] = setting.Value
+			if setting.Label != nil {
+				labelsMap[setting.Name] = *setting.Label
+			}
 		}
 		m.Settings = tfutils.MergeDiagnostics(supertypes.NewMapValueOfMap(ctx, settingsMap))(&diags)
+		m.SettingsLabels = tfutils.MergeDiagnostics(supertypes.NewMapValueOfMap(ctx, labelsMap))(&diags)
 	}
 	return
 }
@@ -899,8 +905,9 @@ func (m IssueAlertActionNotifyEventSentryAppModel) ToApi(ctx context.Context) (*
 	var v apiclient.ProjectRuleAction
 
 	var settings *[]struct {
-		Name  string `json:"name"`
-		Value string `json:"value"`
+		Label *string `json:"label,omitempty"`
+		Name  string  `json:"name"`
+		Value string  `json:"value"`
 	}
 
 	if !m.Settings.IsNull() {
@@ -910,19 +917,33 @@ func (m IssueAlertActionNotifyEventSentryAppModel) ToApi(ctx context.Context) (*
 			return nil, diags
 		}
 
+		labels := make(map[string]string)
+		if !m.SettingsLabels.IsNull() {
+			diags.Append(m.SettingsLabels.ElementsAs(ctx, &labels, false)...)
+			if diags.HasError() {
+				return nil, diags
+			}
+		}
+
 		settings = &[]struct {
-			Name  string `json:"name"`
-			Value string `json:"value"`
+			Label *string `json:"label,omitempty"`
+			Name  string  `json:"name"`
+			Value string  `json:"value"`
 		}{}
 
-		for k, v := range elements {
-			*settings = append(*settings, struct {
-				Name  string `json:"name"`
-				Value string `json:"value"`
+		for k, val := range elements {
+			entry := struct {
+				Label *string `json:"label,omitempty"`
+				Name  string  `json:"name"`
+				Value string  `json:"value"`
 			}{
 				Name:  k,
-				Value: v,
-			})
+				Value: val,
+			}
+			if lbl, ok := labels[k]; ok {
+				entry.Label = &lbl
+			}
+			*settings = append(*settings, entry)
 		}
 	}
 

--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -885,6 +885,7 @@ func (m *IssueAlertActionNotifyEventSentryAppModel) Fill(ctx context.Context, ac
 
 	if action.Settings == nil {
 		m.Settings = supertypes.NewMapValueOfNull[string](ctx)
+		m.SettingsLabels = supertypes.NewMapValueOfNull[string](ctx)
 	} else {
 		var settingsMap = make(map[string]string, len(*action.Settings))
 		var labelsMap = make(map[string]string, len(*action.Settings))

--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -911,16 +911,15 @@ func (m IssueAlertActionNotifyEventSentryAppModel) ToApi(ctx context.Context) (*
 		Value string  `json:"value"`
 	}
 
-	if !m.Settings.IsNull() {
-		elements := make(map[string]string, len(m.Settings.Elements()))
-		diags.Append(m.Settings.ElementsAs(ctx, &elements, false)...)
+	if m.Settings.IsKnown() {
+		elements := tfutils.MergeDiagnostics(m.Settings.Get(ctx))(&diags)
 		if diags.HasError() {
 			return nil, diags
 		}
 
-		labels := make(map[string]string)
-		if !m.SettingsLabels.IsNull() {
-			diags.Append(m.SettingsLabels.ElementsAs(ctx, &labels, false)...)
+		var labels map[string]string
+		if m.SettingsLabels.IsKnown() {
+			labels = tfutils.MergeDiagnostics(m.SettingsLabels.Get(ctx))(&diags)
 			if diags.HasError() {
 				return nil, diags
 			}

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -683,9 +683,8 @@ func (r *IssueAlertResource) ValidateConfig(ctx context.Context, req resource.Va
 		return
 	}
 
-	if !data.ConditionsV2.IsNull() && !data.ConditionsV2.IsUnknown() {
-		var conditions []IssueAlertConditionModel
-		resp.Diagnostics.Append(data.ConditionsV2.ElementsAs(ctx, &conditions, false)...)
+	if data.ConditionsV2.IsKnown() {
+		conditions := tfutils.MergeDiagnostics(data.ConditionsV2.Get(ctx))(&resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -701,9 +700,8 @@ func (r *IssueAlertResource) ValidateConfig(ctx context.Context, req resource.Va
 		}
 	}
 
-	if !data.FiltersV2.IsNull() && !data.FiltersV2.IsUnknown() {
-		var filters []IssueAlertFilterModel
-		resp.Diagnostics.Append(data.FiltersV2.ElementsAs(ctx, &filters, false)...)
+	if data.FiltersV2.IsKnown() {
+		filters := tfutils.MergeDiagnostics(data.FiltersV2.Get(ctx))(&resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -727,9 +725,8 @@ func (r *IssueAlertResource) ValidateConfig(ctx context.Context, req resource.Va
 				"You must add an action for this alert to fire",
 			)
 		}
-	} else if !data.ActionsV2.IsNull() && !data.ActionsV2.IsUnknown() {
-		var actions []IssueAlertActionModel
-		resp.Diagnostics.Append(data.ActionsV2.ElementsAs(ctx, &actions, false)...)
+	} else if data.ActionsV2.IsKnown() {
+		actions := tfutils.MergeDiagnostics(data.ActionsV2.Get(ctx))(&resp.Diagnostics)
 		if resp.Diagnostics.HasError() {
 			return
 		}

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -408,6 +408,12 @@ func (r *IssueAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 									Optional:   true,
 									CustomType: supertypes.NewMapTypeOf[string](ctx),
 								},
+								"settings_labels": schema.MapAttribute{
+									ElementType:         types.StringType,
+									Optional:            true,
+									Computed:            true,
+									MarkdownDescription: "Optional display labels for each settings entry, keyed by setting name. When present, the label is sent to the API so Sentry's frontend can render the correct display name for async-select fields.",
+								},
 							},
 						},
 						"opsgenie_notify_team": {

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -409,10 +409,10 @@ func (r *IssueAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 									CustomType: supertypes.NewMapTypeOf[string](ctx),
 								},
 								"settings_labels": schema.MapAttribute{
-									ElementType:         types.StringType,
+									MarkdownDescription: "Optional mapping of setting keys to human-readable display labels. This is primarily used for `async-select` fields in the Sentry UI.",
 									Optional:            true,
 									Computed:            true,
-									MarkdownDescription: "Optional display labels for each settings entry, keyed by setting name. When present, the label is sent to the API so Sentry's frontend can render the correct display name for async-select fields.",
+									CustomType:          supertypes.NewMapTypeOf[string](ctx),
 								},
 							},
 						},

--- a/internal/provider/resource_issue_alert_test.go
+++ b/internal/provider/resource_issue_alert_test.go
@@ -526,7 +526,7 @@ func TestAccIssueAlertResource_basic(t *testing.T) {
 									"stateId":    knownvalue.StringExact("23e412bc-5abc-4812-916c-f91b4e21a060"),
 									"priority":   knownvalue.StringExact("0"),
 								}),
-								"settings_labels": knownvalue.Null(),
+								"settings_labels": knownvalue.MapExact(map[string]knownvalue.Check{}),
 							}),
 						}),
 						knownvalue.ObjectPartial(map[string]knownvalue.Check{

--- a/internal/provider/resource_issue_alert_test.go
+++ b/internal/provider/resource_issue_alert_test.go
@@ -526,6 +526,7 @@ func TestAccIssueAlertResource_basic(t *testing.T) {
 									"stateId":    knownvalue.StringExact("23e412bc-5abc-4812-916c-f91b4e21a060"),
 									"priority":   knownvalue.StringExact("0"),
 								}),
+								"settings_labels": knownvalue.Null(),
 							}),
 						}),
 						knownvalue.ObjectPartial(map[string]knownvalue.Check{


### PR DESCRIPTION
Adds an optional+computed settings_labels map to the notify_event_sentry_app action so that display labels can be round-tripped through the API. Sentry's frontend requires both a value and a label to render async-select fields correctly when the selected option falls outside the truncated choices window returned by the third-party app webhook.

Non-breaking: existing configs need no changes. The new field is computed, so it is populated automatically from API responses when labels are present.