### PR TITLE
feat: add sentry_app action support to sentry_alert resource

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -902,6 +902,7 @@ Optional:
 - `opsgenie` (Attributes) Notify on OpsGenie. (see [below for nested schema](#nestedatt--action_filters--actions--opsgenie))
 - `pagerduty` (Attributes) Notify on PagerDuty. (see [below for nested schema](#nestedatt--action_filters--actions--pagerduty))
 - `plugin` (Attributes) Send a notification to all legacy integrations (plugins). (see [below for nested schema](#nestedatt--action_filters--actions--plugin))
+- `sentry_app` (Attributes) Trigger an action in a Sentry App (e.g. Rootly). (see [below for nested schema](#nestedatt--action_filters--actions--sentry_app))
 - `slack` (Attributes) Notify on Slack. (see [below for nested schema](#nestedatt--action_filters--actions--slack))
 - `vsts` (Attributes) Notify on Azure DevOps. (see [below for nested schema](#nestedatt--action_filters--actions--vsts))
 
@@ -999,6 +1000,31 @@ Required:
 
 <a id="nestedatt--action_filters--actions--plugin"></a>
 ### Nested Schema for `action_filters.actions.plugin`
+
+
+<a id="nestedatt--action_filters--actions--sentry_app"></a>
+### Nested Schema for `action_filters.actions.sentry_app`
+
+Required:
+
+- `sentry_app_id` (String) The numeric Sentry App ID. Use `tostring(data.sentry_app_installation.<name>.sentry_app_id)` to source this value.
+
+Optional:
+
+- `settings` (Attributes List) Key-value settings passed to the Sentry App action. Specifying `label` preserves the human-readable display name in the Sentry UI for async select fields whose options are paginated by the third-party app. (see [below for nested schema](#nestedatt--action_filters--actions--sentry_app--settings))
+
+<a id="nestedatt--action_filters--actions--sentry_app--settings"></a>
+### Nested Schema for `action_filters.actions.sentry_app.settings`
+
+Required:
+
+- `name` (String) The name of the setting field.
+- `value` (String) The value of the setting field.
+
+Optional:
+
+- `label` (String) The human-readable display label for the value. Required for async select fields whose option list is paginated by the third-party app — without it the field may appear blank under certain conditions in the Sentry UI after apply.
+
 
 
 <a id="nestedatt--action_filters--actions--slack"></a>

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -3491,6 +3491,7 @@ components:
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_Jira"
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_JiraServer"
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_GitHub"
+        - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_SentryApp"
       discriminator:
         propertyName: type
         mapping:
@@ -3505,6 +3506,7 @@ components:
           jira: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_Jira"
           jira_server: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_JiraServer"
           github: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_GitHub"
+          sentry_app: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_SentryApp"
     OrganizationWorkflow_ActionFilter_Action_Email:
       type: object
       required:
@@ -3883,3 +3885,45 @@ components:
                 - specific
         integrationId:
           type: string
+    OrganizationWorkflow_ActionFilter_Action_SentryApp:
+      type: object
+      required:
+        - type
+        - config
+        - data
+      properties:
+        type:
+          type: string
+          enum:
+            - sentry_app
+        data:
+          type: object
+          properties:
+            settings:
+              type: array
+              items:
+                type: object
+                required:
+                  - name
+                  - value
+                properties:
+                  name:
+                    type: string
+                  value:
+                    type: string
+                  label:
+                    type: string
+        config:
+          type: object
+          required:
+            - targetType
+            - targetIdentifier
+          properties:
+            targetType:
+              type: string
+              enum:
+                - sentry_app
+            targetIdentifier:
+              type: string
+            targetDisplay:
+              type: string

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -359,6 +359,36 @@ func (e OrganizationWorkflowActionFilterActionPluginType) Valid() bool {
 	}
 }
 
+// Defines values for OrganizationWorkflowActionFilterActionSentryAppConfigTargetType.
+const (
+	OrganizationWorkflowActionFilterActionSentryAppConfigTargetTypeSentryApp OrganizationWorkflowActionFilterActionSentryAppConfigTargetType = "sentry_app"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationWorkflowActionFilterActionSentryAppConfigTargetType enum.
+func (e OrganizationWorkflowActionFilterActionSentryAppConfigTargetType) Valid() bool {
+	switch e {
+	case OrganizationWorkflowActionFilterActionSentryAppConfigTargetTypeSentryApp:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for OrganizationWorkflowActionFilterActionSentryAppType.
+const (
+	OrganizationWorkflowActionFilterActionSentryAppTypeSentryApp OrganizationWorkflowActionFilterActionSentryAppType = "sentry_app"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationWorkflowActionFilterActionSentryAppType enum.
+func (e OrganizationWorkflowActionFilterActionSentryAppType) Valid() bool {
+	switch e {
+	case OrganizationWorkflowActionFilterActionSentryAppTypeSentryApp:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OrganizationWorkflowActionFilterActionSlackConfigTargetType.
 const (
 	OrganizationWorkflowActionFilterActionSlackConfigTargetTypeSpecific OrganizationWorkflowActionFilterActionSlackConfigTargetType = "specific"
@@ -1759,6 +1789,29 @@ type OrganizationWorkflowActionFilterActionPlugin struct {
 
 // OrganizationWorkflowActionFilterActionPluginType defines model for OrganizationWorkflowActionFilterActionPlugin.Type.
 type OrganizationWorkflowActionFilterActionPluginType string
+
+// OrganizationWorkflowActionFilterActionSentryApp defines model for OrganizationWorkflow_ActionFilter_Action_SentryApp.
+type OrganizationWorkflowActionFilterActionSentryApp struct {
+	Config struct {
+		TargetDisplay    *string                                                         `json:"targetDisplay,omitempty"`
+		TargetIdentifier string                                                          `json:"targetIdentifier"`
+		TargetType       OrganizationWorkflowActionFilterActionSentryAppConfigTargetType `json:"targetType"`
+	} `json:"config"`
+	Data struct {
+		Settings *[]struct {
+			Label *string `json:"label,omitempty"`
+			Name  string  `json:"name"`
+			Value string  `json:"value"`
+		} `json:"settings,omitempty"`
+	} `json:"data"`
+	Type OrganizationWorkflowActionFilterActionSentryAppType `json:"type"`
+}
+
+// OrganizationWorkflowActionFilterActionSentryAppConfigTargetType defines model for OrganizationWorkflowActionFilterActionSentryApp.Config.TargetType.
+type OrganizationWorkflowActionFilterActionSentryAppConfigTargetType string
+
+// OrganizationWorkflowActionFilterActionSentryAppType defines model for OrganizationWorkflowActionFilterActionSentryApp.Type.
+type OrganizationWorkflowActionFilterActionSentryAppType string
 
 // OrganizationWorkflowActionFilterActionSlack defines model for OrganizationWorkflow_ActionFilter_Action_Slack.
 type OrganizationWorkflowActionFilterActionSlack struct {
@@ -3799,6 +3852,34 @@ func (t *OrganizationWorkflowActionFilterAction) MergeOrganizationWorkflowAction
 	return err
 }
 
+// AsOrganizationWorkflowActionFilterActionSentryApp returns the union data inside the OrganizationWorkflowActionFilterAction as a OrganizationWorkflowActionFilterActionSentryApp
+func (t OrganizationWorkflowActionFilterAction) AsOrganizationWorkflowActionFilterActionSentryApp() (OrganizationWorkflowActionFilterActionSentryApp, error) {
+	var body OrganizationWorkflowActionFilterActionSentryApp
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOrganizationWorkflowActionFilterActionSentryApp overwrites any union data inside the OrganizationWorkflowActionFilterAction as the provided OrganizationWorkflowActionFilterActionSentryApp
+func (t *OrganizationWorkflowActionFilterAction) FromOrganizationWorkflowActionFilterActionSentryApp(v OrganizationWorkflowActionFilterActionSentryApp) error {
+	v.Type = "sentry_app"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOrganizationWorkflowActionFilterActionSentryApp performs a merge with any union data inside the OrganizationWorkflowActionFilterAction, using the provided OrganizationWorkflowActionFilterActionSentryApp
+func (t *OrganizationWorkflowActionFilterAction) MergeOrganizationWorkflowActionFilterActionSentryApp(v OrganizationWorkflowActionFilterActionSentryApp) error {
+	v.Type = "sentry_app"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t OrganizationWorkflowActionFilterAction) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -3831,6 +3912,8 @@ func (t OrganizationWorkflowActionFilterAction) ValueByDiscriminator() (interfac
 		return t.AsOrganizationWorkflowActionFilterActionPagerDuty()
 	case "plugin":
 		return t.AsOrganizationWorkflowActionFilterActionPlugin()
+	case "sentry_app":
+		return t.AsOrganizationWorkflowActionFilterActionSentryApp()
 	case "slack":
 		return t.AsOrganizationWorkflowActionFilterActionSlack()
 	case "vsts":

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -588,7 +588,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemEmail](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"target_type": tfutils.WithEnumStringAttribute(
@@ -627,7 +627,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemPlugin](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{},
 									},
@@ -636,7 +636,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemSlack](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -673,7 +673,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemPagerduty](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -703,7 +703,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemDiscord](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -728,7 +728,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemMsteams](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -753,7 +753,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemOpsgenie](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -783,7 +783,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemVsts](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -808,7 +808,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemJira](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -833,7 +833,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemJiraServer](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -858,7 +858,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemGithub](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("sentry_app")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -880,6 +880,46 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												MarkdownDescription: "A list of labels to assign to the issue.",
 												Optional:            true,
 												CustomType:          supertypes.NewSetTypeOf[string](ctx),
+											},
+										},
+									},
+									"sentry_app": schema.SingleNestedAttribute{
+										MarkdownDescription: "Trigger an action in a Sentry App (e.g. Rootly).",
+										Optional:            true,
+										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemSentryApp](ctx),
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+										},
+										Attributes: map[string]schema.Attribute{
+											"sentry_app_id": schema.StringAttribute{
+												MarkdownDescription: "The numeric Sentry App ID. Use `tostring(data.sentry_app_installation.<name>.sentry_app_id)` to source this value.",
+												Required:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"settings": schema.ListNestedAttribute{
+												MarkdownDescription: "Key-value settings passed to the Sentry App action. Specifying `label` preserves the human-readable display name in the Sentry UI for async select fields whose options are paginated by the third-party app.",
+												Optional:            true,
+												CustomType:          supertypes.NewListNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem](ctx),
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"name": schema.StringAttribute{
+															MarkdownDescription: "The name of the setting field.",
+															Required:            true,
+															CustomType:          supertypes.StringType{},
+														},
+														"value": schema.StringAttribute{
+															MarkdownDescription: "The value of the setting field.",
+															Required:            true,
+															CustomType:          supertypes.StringType{},
+														},
+														"label": schema.StringAttribute{
+															MarkdownDescription: "The human-readable display label for the value. Required for async select fields whose option list is paginated by the third-party app — without it the field may appear blank under certain conditions in the Sentry UI after apply.",
+															Optional:            true,
+															Computed:            true,
+															CustomType:          supertypes.StringType{},
+														},
+													},
+												},
 											},
 										},
 									},
@@ -1185,6 +1225,7 @@ type AlertResourceModelActionFiltersItemActionsItem struct {
 	Jira       supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemJira]       `tfsdk:"jira"`
 	JiraServer supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemJiraServer] `tfsdk:"jira_server"`
 	Github     supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemGithub]     `tfsdk:"github"`
+	SentryApp  supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemSentryApp]  `tfsdk:"sentry_app"`
 }
 
 type AlertResourceModelActionFiltersItemActionsItemEmail struct {
@@ -1253,4 +1294,15 @@ type AlertResourceModelActionFiltersItemActionsItemGithub struct {
 	Repo          supertypes.StringValue        `tfsdk:"repo"`
 	Assignee      supertypes.StringValue        `tfsdk:"assignee"`
 	Labels        supertypes.SetValueOf[string] `tfsdk:"labels"`
+}
+
+type AlertResourceModelActionFiltersItemActionsItemSentryApp struct {
+	SentryAppId supertypes.StringValue                                                                                  `tfsdk:"sentry_app_id"`
+	Settings    supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem] `tfsdk:"settings"`
+}
+
+type AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem struct {
+	Name  supertypes.StringValue `tfsdk:"name"`
+	Value supertypes.StringValue `tfsdk:"value"`
+	Label supertypes.StringValue `tfsdk:"label"`
 }

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -521,6 +521,45 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 					return nil, diags
 				}
 
+			case inAction.SentryApp.IsKnown():
+				inSentryApp := inAction.SentryApp.DiagsGet(ctx, diags)
+				if diags.HasError() {
+					return nil, diags
+				}
+
+				var outSentryApp apiclient.OrganizationWorkflowActionFilterActionSentryApp
+				outSentryApp.Config.TargetType = "sentry_app"
+				outSentryApp.Config.TargetIdentifier = inSentryApp.SentryAppId.Get()
+
+				if inSentryApp.Settings.IsKnown() {
+					inSettings := inSentryApp.Settings.DiagsGet(ctx, diags)
+					if diags.HasError() {
+						return nil, diags
+					}
+					settings := make([]struct {
+						Label *string `json:"label,omitempty"`
+						Name  string  `json:"name"`
+						Value string  `json:"value"`
+					}, 0, len(inSettings))
+					for _, s := range inSettings {
+						settings = append(settings, struct {
+							Label *string `json:"label,omitempty"`
+							Name  string  `json:"name"`
+							Value string  `json:"value"`
+						}{
+							Name:  s.Name.Get(),
+							Value: s.Value.Get(),
+							Label: s.Label.GetPtr(),
+						})
+					}
+					outSentryApp.Data.Settings = &settings
+				}
+
+				if err := outAction.FromOrganizationWorkflowActionFilterActionSentryApp(outSentryApp); err != nil {
+					diags.AddError("Failed to create action", err.Error())
+					return nil, diags
+				}
+
 			}
 
 			outActions = append(outActions, outAction)
@@ -864,6 +903,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				Jira:       supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemJira](ctx),
 				JiraServer: supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemJiraServer](ctx),
 				Github:     supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemGithub](ctx),
+				SentryApp:  supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemSentryApp](ctx),
 			}
 
 			actionValue, err := action.ValueByDiscriminator()
@@ -974,6 +1014,26 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				outGithub.Labels = supertypes.NewSetValueOfSlice(ctx, actionValue.Data.AdditionalFields.Labels)
 
 				outAction.Github = supertypes.NewSingleNestedObjectValueOf(ctx, &outGithub)
+
+			case apiclient.OrganizationWorkflowActionFilterActionSentryApp:
+				var outSentryApp AlertResourceModelActionFiltersItemActionsItemSentryApp
+				outSentryApp.SentryAppId = supertypes.NewStringValue(actionValue.Config.TargetIdentifier)
+
+				if actionValue.Data.Settings != nil {
+					items := []AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem{}
+					for _, s := range *actionValue.Data.Settings {
+						items = append(items, AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem{
+							Name:  supertypes.NewStringValue(s.Name),
+							Value: supertypes.NewStringValue(s.Value),
+							Label: supertypes.NewStringPointerValueOrNull(s.Label),
+						})
+					}
+					outSentryApp.Settings = supertypes.NewListNestedObjectValueOfValueSlice(ctx, items)
+				} else {
+					outSentryApp.Settings = supertypes.NewListNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem](ctx)
+				}
+
+				outAction.SentryApp = supertypes.NewSingleNestedObjectValueOf(ctx, &outSentryApp)
 			}
 
 			if diags.HasError() {

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -859,6 +859,49 @@ export default {
                 },
               ],
             },
+            {
+              name: "sentry_app",
+              type: "single_nested",
+              description: "Trigger an action in a Sentry App (e.g. Rootly).",
+              computedOptionalRequired: "optional",
+              attributes: [
+                {
+                  name: "sentry_app_id",
+                  type: "string",
+                  description:
+                    "The numeric Sentry App ID. Use `tostring(data.sentry_app_installation.<name>.sentry_app_id)` to source this value.",
+                  computedOptionalRequired: "required",
+                },
+                {
+                  name: "settings",
+                  type: "list_nested",
+                  description:
+                    "Key-value settings passed to the Sentry App action. Specifying `label` preserves the human-readable display name in the Sentry UI for async select fields whose options are paginated by the third-party app.",
+                  computedOptionalRequired: "optional",
+                  attributes: [
+                    {
+                      name: "name",
+                      type: "string",
+                      description: "The name of the setting field.",
+                      computedOptionalRequired: "required",
+                    },
+                    {
+                      name: "value",
+                      type: "string",
+                      description: "The value of the setting field.",
+                      computedOptionalRequired: "required",
+                    },
+                    {
+                      name: "label",
+                      type: "string",
+                      description:
+                        "The human-readable display label for the value. Required for async select fields whose option list is paginated by the third-party app — without it the field may appear blank under certain conditions in the Sentry UI after apply.",
+                      computedOptionalRequired: "computed_optional",
+                    },
+                  ],
+                },
+              ],
+            },
           ]),
         },
       ],


### PR DESCRIPTION
Adds support for the sentry_app action type in the workflow-engine sentry_alert resource. Previously, importing a workflow with a notify_event_sentry_app action (e.g. Rootly) would fail with "unknown discriminator value: sentry_app".

Includes label field on settings items so async-select fields in the Sentry UI render correctly when the third-party app's webhook response is paginated.