### PR TITLE
fix(issue-alert): eliminate infinite drift on legacy actions with Sen…

### DIFF
--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -1548,6 +1549,7 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 	if !m.Actions.IsNull() {
 		apiActions := lo.Map(alert.Actions, func(a apiclient.ProjectRuleAction, _ int) json.RawMessage {
 			b, _ := json.Marshal(a)
+			b, _ = stripLegacyActionDisplayFields(b)
 			return b
 		})
 		var priorActions []json.RawMessage
@@ -1590,4 +1592,24 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 	}
 
 	return
+}
+
+// stripLegacyActionDisplayFields removes API-injected display-only keys from the legacy
+// action JSON before storing in state. The Sentry GET endpoint unconditionally adds
+// "formFields" (live webhook schema) and "name" (generated label) to every action dict.
+// These fields are never stored server-side and cannot be stabilized in config.
+func stripLegacyActionDisplayFields(actionJSON []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(actionJSON))
+	dec.UseNumber()
+
+	var action map[string]interface{}
+	if err := dec.Decode(&action); err != nil {
+		return nil, err
+	}
+
+	delete(action, "formFields")
+	delete(action, "name")
+	delete(action, "hasSchemaFormConfig")
+
+	return json.Marshal(action)
 }

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -801,6 +801,12 @@ func (r *IssueAlertResource) Create(ctx context.Context, req resource.CreateRequ
 
 	if !data.Actions.IsNull() {
 		resp.Diagnostics.Append(data.Actions.Unmarshal(&body.Actions)...)
+		if !resp.Diagnostics.HasError() {
+			if err := injectLegacyActionsHasSchemaFormConfig(body.Actions); err != nil {
+				resp.Diagnostics.AddError("Failed to normalize actions", err.Error())
+				return
+			}
+		}
 	} else if !data.ActionsV2.IsNull() {
 		var actions []IssueAlertActionModel
 		resp.Diagnostics.Append(data.ActionsV2.ElementsAs(ctx, &actions, false)...)
@@ -960,6 +966,12 @@ func (r *IssueAlertResource) Update(ctx context.Context, req resource.UpdateRequ
 
 	if !data.Actions.IsNull() {
 		resp.Diagnostics.Append(data.Actions.Unmarshal(&body.Actions)...)
+		if !resp.Diagnostics.HasError() {
+			if err := injectLegacyActionsHasSchemaFormConfig(body.Actions); err != nil {
+				resp.Diagnostics.AddError("Failed to normalize actions", err.Error())
+				return
+			}
+		}
 	} else if !data.ActionsV2.IsNull() {
 		var actions []IssueAlertActionModel
 		resp.Diagnostics.Append(data.ActionsV2.ElementsAs(ctx, &actions, false)...)
@@ -1184,4 +1196,25 @@ func (r *IssueAlertResource) UpgradeState(ctx context.Context) map[int64]resourc
 			},
 		},
 	}
+}
+
+// injectLegacyActionsHasSchemaFormConfig ensures hasSchemaFormConfig is always true for
+// notify_event_sentry_app actions in the legacy actions payload. The field is required by
+// the Sentry API but never returned in GET responses, so we inject it automatically rather
+// than requiring users to include it in their jsonencode config.
+func injectLegacyActionsHasSchemaFormConfig(actions []apiclient.ProjectRuleAction) error {
+	for i, action := range actions {
+		sentryApp, err := action.AsProjectRuleActionNotifyEventSentryApp()
+		if err != nil {
+			continue
+		}
+		if sentryApp.Id != apiclient.SentryRulesActionsNotifyEventSentryAppNotifyEventSentryAppAction {
+			continue
+		}
+		sentryApp.HasSchemaFormConfig = true
+		if err := actions[i].FromProjectRuleActionNotifyEventSentryApp(sentryApp); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
…try App actions

The Sentry GET endpoint unconditionally injects `formFields` (live webhook schema), `name` (generated label), and omits `hasSchemaFormConfig` from every `notify_event_sentry_app` action dict. These fields are never stored server-side, causing the legacy `actions` attribute to drift on every plan.

- Strip `formFields`, `name`, and `hasSchemaFormConfig` from the API response before writing to state via `stripLegacyActionsDisplayFields`
- Inject `hasSchemaFormConfig: true` automatically in Create/Update for `notify_event_sentry_app` actions via `injectLegacyActionsHasSchemaFormConfig`, matching the behaviour of the `actions_v2` typed path

Users no longer need `hasSchemaFormConfig` in their `jsonencode` config; removing it eliminates all remaining drift for Sentry App actions.