### PR TITLE
fix(alert): add issue_type condition, fix event_attribute is/ns, add …

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1142,7 +1142,7 @@ Optional:
 
 - `attribute` (String) The attribute of the filter. Conflicts with `key`.
 - `key` (String) The key of the filter. Conflicts with `attribute`.
-- `match` (String) The match type of the filter.
+- `match` (String) The match type of the filter. Valid values are: `co`, `ew`, `eq`, `gte`, `gt`, `is`, `in`, `lte`, `lt`, `nc`, `new`, `ne`, `ns`, `nsw`, `nin`, and `sw`.
 - `value` (String) The value of the filter.
 
 
@@ -1167,7 +1167,7 @@ Optional:
 
 - `attribute` (String) The attribute of the filter. Conflicts with `key`.
 - `key` (String) The key of the filter. Conflicts with `attribute`.
-- `match` (String) The match type of the filter.
+- `match` (String) The match type of the filter. Valid values are: `co`, `ew`, `eq`, `gte`, `gt`, `is`, `in`, `lte`, `lt`, `nc`, `new`, `ne`, `ns`, `nsw`, `nin`, and `sw`.
 - `value` (String) The value of the filter.
 
 
@@ -1289,7 +1289,7 @@ Optional:
 
 - `attribute` (String) The attribute of the filter. Conflicts with `key`.
 - `key` (String) The key of the filter. Conflicts with `attribute`.
-- `match` (String) The match type of the filter.
+- `match` (String) The match type of the filter. Valid values are: `co`, `ew`, `eq`, `gte`, `gt`, `is`, `in`, `lte`, `lt`, `nc`, `new`, `ne`, `ns`, `nsw`, `nin`, and `sw`.
 - `value` (String) The value of the filter.
 
 

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1083,6 +1083,7 @@ Optional:
 - `issue_occurrences` (Attributes) Issue frequency. (see [below for nested schema](#nestedatt--action_filters--conditions--issue_occurrences))
 - `issue_priority_deescalating` (Attributes) De-escalation. (see [below for nested schema](#nestedatt--action_filters--conditions--issue_priority_deescalating))
 - `issue_priority_greater_or_equal` (Attributes) Issue priority. (see [below for nested schema](#nestedatt--action_filters--conditions--issue_priority_greater_or_equal))
+- `issue_type` (Attributes) Issue type is (or is not) `value`. (see [below for nested schema](#nestedatt--action_filters--conditions--issue_type))
 - `latest_adopted_release` (Attributes) The `release_age_type` adopted release associated with the event's issue is `age_comparison` than the latest adopted release in `environment`. (see [below for nested schema](#nestedatt--action_filters--conditions--latest_adopted_release))
 - `latest_release` (Attributes) The event is from the latest release. (see [below for nested schema](#nestedatt--action_filters--conditions--latest_release))
 - `level` (Attributes) The event's level match `level`. (see [below for nested schema](#nestedatt--action_filters--conditions--level))
@@ -1116,7 +1117,10 @@ Required:
 
 - `attribute` (String) The attribute to evaluate.
 - `match` (String) The match type.
-- `value` (String) The value to compare against.
+
+Optional:
+
+- `value` (String) The value to compare against. Not required when `match` is `is` or `ns`.
 
 
 <a id="nestedatt--action_filters--conditions--event_frequency_count"></a>
@@ -1127,6 +1131,21 @@ Required:
 - `interval` (String) The time period in which to evaluate the value. e.g. Number of events in an issue is more than `value` in `interval`. Valid values are: `1m`, `5m`, `15m`, `1h`, `1d`, `1w`, and `30d`.
 - `value` (Number) A positive integer representing the number of events in an issue that must come in before the alert will fire.
 
+Optional:
+
+- `filters` (Attributes List) A list of additional sub-filters to evaluate before the alert will fire. (see [below for nested schema](#nestedatt--action_filters--conditions--event_frequency_count--filters))
+
+<a id="nestedatt--action_filters--conditions--event_frequency_count--filters"></a>
+### Nested Schema for `action_filters.conditions.event_frequency_count.filters`
+
+Optional:
+
+- `attribute` (String) The attribute of the filter. Conflicts with `key`.
+- `key` (String) The key of the filter. Conflicts with `attribute`.
+- `match` (String) The match type of the filter.
+- `value` (String) The value of the filter.
+
+
 
 <a id="nestedatt--action_filters--conditions--event_frequency_percent"></a>
 ### Nested Schema for `action_filters.conditions.event_frequency_percent`
@@ -1136,6 +1155,21 @@ Required:
 - `comparison_interval` (String) The time period to compare against. Valid values are: `1m`, `5m`, `15m`, `1h`, `1d`, `1w`, and `30d`.
 - `interval` (String) The time period in which to evaluate the value. e.g. Number of events in an issue is `comparisonInterval` percent higher `value` compared to `interval`. Valid values are: `1m`, `5m`, `15m`, `1h`, `1d`, `1w`, and `30d`.
 - `value` (Number) A positive integer representing the number of events in an issue that must come in before the alert will fire.
+
+Optional:
+
+- `filters` (Attributes List) A list of additional sub-filters to evaluate before the alert will fire. (see [below for nested schema](#nestedatt--action_filters--conditions--event_frequency_percent--filters))
+
+<a id="nestedatt--action_filters--conditions--event_frequency_percent--filters"></a>
+### Nested Schema for `action_filters.conditions.event_frequency_percent.filters`
+
+Optional:
+
+- `attribute` (String) The attribute of the filter. Conflicts with `key`.
+- `key` (String) The key of the filter. Conflicts with `attribute`.
+- `match` (String) The match type of the filter.
+- `value` (String) The value of the filter.
+
 
 
 <a id="nestedatt--action_filters--conditions--event_unique_user_frequency_count"></a>
@@ -1194,6 +1228,15 @@ Required:
 - `comparison` (Number) he priority the issue must be for the alert to fire.
 
 
+<a id="nestedatt--action_filters--conditions--issue_type"></a>
+### Nested Schema for `action_filters.conditions.issue_type`
+
+Required:
+
+- `include` (Boolean) If `true`, matches when the issue type equals `value`. If `false`, matches when it does not equal `value`.
+- `value` (String) The issue type slug (e.g. `performance_large_http_payload`).
+
+
 <a id="nestedatt--action_filters--conditions--latest_adopted_release"></a>
 ### Nested Schema for `action_filters.conditions.latest_adopted_release`
 
@@ -1234,6 +1277,21 @@ Required:
 - `comparison_interval` (String) The time period to compare against. Valid values are: `1m`, `5m`, `15m`, `1h`, `1d`, `1w`, and `30d`.
 - `interval` (String) The time period in which to evaluate the value. e.g. Percentage of sessions affected by an issue is `comparisonInterval` percent higher `value` compared to `interval`. Valid values are: `1m`, `5m`, `15m`, `1h`, `1d`, `1w`, and `30d`.
 - `value` (Number) A positive integer representing the number of events in an issue that must come in before the alert will fire.
+
+Optional:
+
+- `filters` (Attributes List) A list of additional sub-filters to evaluate before the alert will fire. (see [below for nested schema](#nestedatt--action_filters--conditions--percent_sessions_percent--filters))
+
+<a id="nestedatt--action_filters--conditions--percent_sessions_percent--filters"></a>
+### Nested Schema for `action_filters.conditions.percent_sessions_percent.filters`
+
+Optional:
+
+- `attribute` (String) The attribute of the filter. Conflicts with `key`.
+- `key` (String) The key of the filter. Conflicts with `attribute`.
+- `match` (String) The match type of the filter.
+- `value` (String) The value of the filter.
+
 
 
 <a id="nestedatt--action_filters--conditions--tagged_event"></a>

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -3079,6 +3079,7 @@ components:
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_LatestRelease"
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_LatestAdoptedRelease"
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_Level"
+        - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_IssueType"
       discriminator:
         propertyName: type
         mapping:
@@ -3098,6 +3099,7 @@ components:
           latest_release: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_LatestRelease"
           latest_adopted_release: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_LatestAdoptedRelease"
           level: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_Level"
+          issue_type: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_IssueType"
     OrganizationWorkflow_ActionFilter_Condition_AgeComparison:
       type: object
       required:
@@ -3298,6 +3300,10 @@ components:
             value:
               type: integer
               format: int64
+            filters:
+              type: array
+              items:
+                $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_EventUniqueUserFrequencyCount_Filter"
             interval:
               type: string
         conditionResult:
@@ -3323,6 +3329,10 @@ components:
             value:
               type: integer
               format: int64
+            filters:
+              type: array
+              items:
+                $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_EventUniqueUserFrequencyCount_Filter"
             interval:
               type: string
             comparisonInterval:
@@ -3374,6 +3384,10 @@ components:
             value:
               type: integer
               format: int64
+            filters:
+              type: array
+              items:
+                $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Condition_EventUniqueUserFrequencyCount_Filter"
             interval:
               type: string
             comparisonInterval:
@@ -3396,7 +3410,6 @@ components:
           required:
             - attribute
             - match
-            - value
           properties:
             attribute:
               type: string
@@ -3945,3 +3958,26 @@ components:
               type: string
             targetDisplay:
               type: string
+    OrganizationWorkflow_ActionFilter_Condition_IssueType:
+      type: object
+      required:
+        - type
+        - comparison
+        - conditionResult
+      properties:
+        type:
+          type: string
+          enum:
+            - issue_type
+        comparison:
+          type: object
+          required:
+            - value
+            - include
+          properties:
+            value:
+              type: string
+            include:
+              type: boolean
+        conditionResult:
+          type: boolean

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -662,6 +662,21 @@ func (e OrganizationWorkflowActionFilterConditionIssuePriorityGreaterOrEqualType
 	}
 }
 
+// Defines values for OrganizationWorkflowActionFilterConditionIssueTypeType.
+const (
+	IssueType OrganizationWorkflowActionFilterConditionIssueTypeType = "issue_type"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationWorkflowActionFilterConditionIssueTypeType enum.
+func (e OrganizationWorkflowActionFilterConditionIssueTypeType) Valid() bool {
+	switch e {
+	case IssueType:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OrganizationWorkflowActionFilterConditionLatestAdoptedReleaseType.
 const (
 	LatestAdoptedRelease OrganizationWorkflowActionFilterConditionLatestAdoptedReleaseType = "latest_adopted_release"
@@ -1910,9 +1925,9 @@ type OrganizationWorkflowActionFilterConditionAssignedToType string
 // OrganizationWorkflowActionFilterConditionEventAttribute defines model for OrganizationWorkflow_ActionFilter_Condition_EventAttribute.
 type OrganizationWorkflowActionFilterConditionEventAttribute struct {
 	Comparison struct {
-		Attribute string `json:"attribute"`
-		Match     string `json:"match"`
-		Value     string `json:"value"`
+		Attribute string  `json:"attribute"`
+		Match     string  `json:"match"`
+		Value     *string `json:"value,omitempty"`
 	} `json:"comparison"`
 	ConditionResult bool                                                        `json:"conditionResult"`
 	Type            OrganizationWorkflowActionFilterConditionEventAttributeType `json:"type"`
@@ -1924,8 +1939,9 @@ type OrganizationWorkflowActionFilterConditionEventAttributeType string
 // OrganizationWorkflowActionFilterConditionEventFrequencyCount defines model for OrganizationWorkflow_ActionFilter_Condition_EventFrequencyCount.
 type OrganizationWorkflowActionFilterConditionEventFrequencyCount struct {
 	Comparison struct {
-		Interval string `json:"interval"`
-		Value    int64  `json:"value"`
+		Filters  *[]OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter `json:"filters,omitempty"`
+		Interval string                                                                          `json:"interval"`
+		Value    int64                                                                           `json:"value"`
 	} `json:"comparison"`
 	ConditionResult bool                                                             `json:"conditionResult"`
 	Type            OrganizationWorkflowActionFilterConditionEventFrequencyCountType `json:"type"`
@@ -1937,9 +1953,10 @@ type OrganizationWorkflowActionFilterConditionEventFrequencyCountType string
 // OrganizationWorkflowActionFilterConditionEventFrequencyPercent defines model for OrganizationWorkflow_ActionFilter_Condition_EventFrequencyPercent.
 type OrganizationWorkflowActionFilterConditionEventFrequencyPercent struct {
 	Comparison struct {
-		ComparisonInterval string `json:"comparisonInterval"`
-		Interval           string `json:"interval"`
-		Value              int64  `json:"value"`
+		ComparisonInterval string                                                                          `json:"comparisonInterval"`
+		Filters            *[]OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter `json:"filters,omitempty"`
+		Interval           string                                                                          `json:"interval"`
+		Value              int64                                                                           `json:"value"`
 	} `json:"comparison"`
 	ConditionResult bool                                                               `json:"conditionResult"`
 	Type            OrganizationWorkflowActionFilterConditionEventFrequencyPercentType `json:"type"`
@@ -2015,6 +2032,19 @@ type OrganizationWorkflowActionFilterConditionIssuePriorityGreaterOrEqual struct
 // OrganizationWorkflowActionFilterConditionIssuePriorityGreaterOrEqualType defines model for OrganizationWorkflowActionFilterConditionIssuePriorityGreaterOrEqual.Type.
 type OrganizationWorkflowActionFilterConditionIssuePriorityGreaterOrEqualType string
 
+// OrganizationWorkflowActionFilterConditionIssueType defines model for OrganizationWorkflow_ActionFilter_Condition_IssueType.
+type OrganizationWorkflowActionFilterConditionIssueType struct {
+	Comparison struct {
+		Include bool   `json:"include"`
+		Value   string `json:"value"`
+	} `json:"comparison"`
+	ConditionResult bool                                                   `json:"conditionResult"`
+	Type            OrganizationWorkflowActionFilterConditionIssueTypeType `json:"type"`
+}
+
+// OrganizationWorkflowActionFilterConditionIssueTypeType defines model for OrganizationWorkflowActionFilterConditionIssueType.Type.
+type OrganizationWorkflowActionFilterConditionIssueTypeType string
+
 // OrganizationWorkflowActionFilterConditionLatestAdoptedRelease defines model for OrganizationWorkflow_ActionFilter_Condition_LatestAdoptedRelease.
 type OrganizationWorkflowActionFilterConditionLatestAdoptedRelease struct {
 	Comparison struct {
@@ -2068,9 +2098,10 @@ type OrganizationWorkflowActionFilterConditionPercentSessionsCountType string
 // OrganizationWorkflowActionFilterConditionPercentSessionsPercent defines model for OrganizationWorkflow_ActionFilter_Condition_PercentSessionsPercent.
 type OrganizationWorkflowActionFilterConditionPercentSessionsPercent struct {
 	Comparison struct {
-		ComparisonInterval string `json:"comparisonInterval"`
-		Interval           string `json:"interval"`
-		Value              int64  `json:"value"`
+		ComparisonInterval string                                                                          `json:"comparisonInterval"`
+		Filters            *[]OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter `json:"filters,omitempty"`
+		Interval           string                                                                          `json:"interval"`
+		Value              int64                                                                           `json:"value"`
 	} `json:"comparison"`
 	ConditionResult bool                                                                `json:"conditionResult"`
 	Type            OrganizationWorkflowActionFilterConditionPercentSessionsPercentType `json:"type"`
@@ -4388,6 +4419,34 @@ func (t *OrganizationWorkflowActionFilterCondition) MergeOrganizationWorkflowAct
 	return err
 }
 
+// AsOrganizationWorkflowActionFilterConditionIssueType returns the union data inside the OrganizationWorkflowActionFilterCondition as a OrganizationWorkflowActionFilterConditionIssueType
+func (t OrganizationWorkflowActionFilterCondition) AsOrganizationWorkflowActionFilterConditionIssueType() (OrganizationWorkflowActionFilterConditionIssueType, error) {
+	var body OrganizationWorkflowActionFilterConditionIssueType
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOrganizationWorkflowActionFilterConditionIssueType overwrites any union data inside the OrganizationWorkflowActionFilterCondition as the provided OrganizationWorkflowActionFilterConditionIssueType
+func (t *OrganizationWorkflowActionFilterCondition) FromOrganizationWorkflowActionFilterConditionIssueType(v OrganizationWorkflowActionFilterConditionIssueType) error {
+	v.Type = "issue_type"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOrganizationWorkflowActionFilterConditionIssueType performs a merge with any union data inside the OrganizationWorkflowActionFilterCondition, using the provided OrganizationWorkflowActionFilterConditionIssueType
+func (t *OrganizationWorkflowActionFilterCondition) MergeOrganizationWorkflowActionFilterConditionIssueType(v OrganizationWorkflowActionFilterConditionIssueType) error {
+	v.Type = "issue_type"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t OrganizationWorkflowActionFilterCondition) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -4422,6 +4481,8 @@ func (t OrganizationWorkflowActionFilterCondition) ValueByDiscriminator() (inter
 		return t.AsOrganizationWorkflowActionFilterConditionIssuePriorityDeescalating()
 	case "issue_priority_greater_or_equal":
 		return t.AsOrganizationWorkflowActionFilterConditionIssuePriorityGreaterOrEqual()
+	case "issue_type":
+		return t.AsOrganizationWorkflowActionFilterConditionIssueType()
 	case "latest_adopted_release":
 		return t.AsOrganizationWorkflowActionFilterConditionLatestAdoptedRelease()
 	case "latest_release":

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -383,11 +383,14 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key")),
 															},
 														},
-														"match": schema.StringAttribute{
-															MarkdownDescription: "The match type of the filter.",
-															Optional:            true,
-															CustomType:          supertypes.StringType{},
-														},
+														"match": tfutils.WithEnumStringAttribute(
+															schema.StringAttribute{
+																MarkdownDescription: "The match type of the filter.",
+																Optional:            true,
+																CustomType:          supertypes.StringType{},
+															},
+															sentrydata.MatchTypeIds,
+														),
 														"value": schema.StringAttribute{
 															MarkdownDescription: "The value of the filter.",
 															Optional:            true,
@@ -445,11 +448,14 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key")),
 															},
 														},
-														"match": schema.StringAttribute{
-															MarkdownDescription: "The match type of the filter.",
-															Optional:            true,
-															CustomType:          supertypes.StringType{},
-														},
+														"match": tfutils.WithEnumStringAttribute(
+															schema.StringAttribute{
+																MarkdownDescription: "The match type of the filter.",
+																Optional:            true,
+																CustomType:          supertypes.StringType{},
+															},
+															sentrydata.MatchTypeIds,
+														),
 														"value": schema.StringAttribute{
 															MarkdownDescription: "The value of the filter.",
 															Optional:            true,
@@ -541,11 +547,14 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key")),
 															},
 														},
-														"match": schema.StringAttribute{
-															MarkdownDescription: "The match type of the filter.",
-															Optional:            true,
-															CustomType:          supertypes.StringType{},
-														},
+														"match": tfutils.WithEnumStringAttribute(
+															schema.StringAttribute{
+																MarkdownDescription: "The match type of the filter.",
+																Optional:            true,
+																CustomType:          supertypes.StringType{},
+															},
+															sentrydata.MatchTypeIds,
+														),
 														"value": schema.StringAttribute{
 															MarkdownDescription: "The value of the filter.",
 															Optional:            true,
@@ -642,7 +651,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemLatestAdoptedRelease](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"environment": schema.StringAttribute{
@@ -1311,9 +1320,9 @@ type AlertResourceModelActionFiltersItemConditionsItemEventUniqueUserFrequencyCo
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCount struct {
-	Value    supertypes.Int64Value                                                                                                       `tfsdk:"value"`
-	Filters  supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem]         `tfsdk:"filters"`
-	Interval supertypes.StringValue                                                                                                      `tfsdk:"interval"`
+	Value    supertypes.Int64Value                                                                                               `tfsdk:"value"`
+	Filters  supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem] `tfsdk:"filters"`
+	Interval supertypes.StringValue                                                                                              `tfsdk:"interval"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem struct {
@@ -1324,10 +1333,10 @@ type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFilters
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercent struct {
-	Value              supertypes.Int64Value                                                                                                          `tfsdk:"value"`
-	Filters            supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem]           `tfsdk:"filters"`
-	Interval           supertypes.StringValue                                                                                                         `tfsdk:"interval"`
-	ComparisonInterval supertypes.StringValue                                                                                                         `tfsdk:"comparison_interval"`
+	Value              supertypes.Int64Value                                                                                                 `tfsdk:"value"`
+	Filters            supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem] `tfsdk:"filters"`
+	Interval           supertypes.StringValue                                                                                                `tfsdk:"interval"`
+	ComparisonInterval supertypes.StringValue                                                                                                `tfsdk:"comparison_interval"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem struct {
@@ -1343,10 +1352,10 @@ type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsCount struc
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercent struct {
-	Value              supertypes.Int64Value                                                                                                              `tfsdk:"value"`
-	Filters            supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem]               `tfsdk:"filters"`
-	Interval           supertypes.StringValue                                                                                                              `tfsdk:"interval"`
-	ComparisonInterval supertypes.StringValue                                                                                                              `tfsdk:"comparison_interval"`
+	Value              supertypes.Int64Value                                                                                                  `tfsdk:"value"`
+	Filters            supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem] `tfsdk:"filters"`
+	Interval           supertypes.StringValue                                                                                                 `tfsdk:"interval"`
+	ComparisonInterval supertypes.StringValue                                                                                                 `tfsdk:"comparison_interval"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem struct {

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -163,7 +163,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemAgeComparison](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"time": tfutils.WithEnumStringAttribute(
@@ -197,7 +197,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemAssignedTo](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"target_type": tfutils.WithEnumStringAttribute(
@@ -224,7 +224,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemIssueCategory](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -245,7 +245,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemIssueOccurrences](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -263,7 +263,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemIssuePriorityDeescalating](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{},
 									},
@@ -272,7 +272,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemIssuePriorityGreaterOrEqual](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"comparison": schema.Int64Attribute{
@@ -287,7 +287,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemEventUniqueUserFrequencyCount](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -349,7 +349,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCount](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -358,6 +358,42 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												CustomType:          supertypes.Int64Type{},
 												Validators: []validator.Int64{
 													int64validator.AtLeast(1),
+												},
+											},
+											"filters": schema.ListNestedAttribute{
+												MarkdownDescription: "A list of additional sub-filters to evaluate before the alert will fire.",
+												Optional:            true,
+												Computed:            true,
+												CustomType:          supertypes.NewListNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem](ctx),
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"key": schema.StringAttribute{
+															MarkdownDescription: "The key of the filter. Conflicts with `attribute`.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+															Validators: []validator.String{
+																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("attribute")),
+															},
+														},
+														"attribute": schema.StringAttribute{
+															MarkdownDescription: "The attribute of the filter. Conflicts with `key`.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+															Validators: []validator.String{
+																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key")),
+															},
+														},
+														"match": schema.StringAttribute{
+															MarkdownDescription: "The match type of the filter.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+														},
+														"value": schema.StringAttribute{
+															MarkdownDescription: "The value of the filter.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+														},
+													},
 												},
 											},
 											"interval": tfutils.WithEnumStringAttribute(
@@ -375,7 +411,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercent](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -384,6 +420,42 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												CustomType:          supertypes.Int64Type{},
 												Validators: []validator.Int64{
 													int64validator.AtLeast(1),
+												},
+											},
+											"filters": schema.ListNestedAttribute{
+												MarkdownDescription: "A list of additional sub-filters to evaluate before the alert will fire.",
+												Optional:            true,
+												Computed:            true,
+												CustomType:          supertypes.NewListNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem](ctx),
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"key": schema.StringAttribute{
+															MarkdownDescription: "The key of the filter. Conflicts with `attribute`.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+															Validators: []validator.String{
+																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("attribute")),
+															},
+														},
+														"attribute": schema.StringAttribute{
+															MarkdownDescription: "The attribute of the filter. Conflicts with `key`.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+															Validators: []validator.String{
+																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key")),
+															},
+														},
+														"match": schema.StringAttribute{
+															MarkdownDescription: "The match type of the filter.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+														},
+														"value": schema.StringAttribute{
+															MarkdownDescription: "The value of the filter.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+														},
+													},
 												},
 											},
 											"interval": tfutils.WithEnumStringAttribute(
@@ -409,7 +481,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemPercentSessionsCount](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -435,7 +507,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercent](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"value": schema.Int64Attribute{
@@ -444,6 +516,42 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												CustomType:          supertypes.Int64Type{},
 												Validators: []validator.Int64{
 													int64validator.AtLeast(1),
+												},
+											},
+											"filters": schema.ListNestedAttribute{
+												MarkdownDescription: "A list of additional sub-filters to evaluate before the alert will fire.",
+												Optional:            true,
+												Computed:            true,
+												CustomType:          supertypes.NewListNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem](ctx),
+												NestedObject: schema.NestedAttributeObject{
+													Attributes: map[string]schema.Attribute{
+														"key": schema.StringAttribute{
+															MarkdownDescription: "The key of the filter. Conflicts with `attribute`.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+															Validators: []validator.String{
+																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("attribute")),
+															},
+														},
+														"attribute": schema.StringAttribute{
+															MarkdownDescription: "The attribute of the filter. Conflicts with `key`.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+															Validators: []validator.String{
+																stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key")),
+															},
+														},
+														"match": schema.StringAttribute{
+															MarkdownDescription: "The match type of the filter.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+														},
+														"value": schema.StringAttribute{
+															MarkdownDescription: "The value of the filter.",
+															Optional:            true,
+															CustomType:          supertypes.StringType{},
+														},
+													},
 												},
 											},
 											"interval": tfutils.WithEnumStringAttribute(
@@ -469,7 +577,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemEventAttribute](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"attribute": schema.StringAttribute{
@@ -483,9 +591,12 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												CustomType:          supertypes.StringType{},
 											},
 											"value": schema.StringAttribute{
-												MarkdownDescription: "The value to compare against.",
-												Required:            true,
+												MarkdownDescription: "The value to compare against. Not required when `match` is `is` or `ns`.",
+												Optional:            true,
 												CustomType:          supertypes.StringType{},
+												Validators: []validator.String{
+													fstringvalidator.NullIfAttributeIsOneOf(path.MatchRelative().AtParent().AtName("match"), []attr.Value{supertypes.NewStringValue("is"), supertypes.NewStringValue("ns")}),
+												},
 											},
 										},
 									},
@@ -494,7 +605,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemTaggedEvent](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"key": schema.StringAttribute{
@@ -522,7 +633,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemLatestRelease](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{},
 									},
@@ -562,7 +673,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemLevel](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("issue_type")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"match": schema.StringAttribute{
@@ -574,6 +685,26 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												MarkdownDescription: "The level to compare against.",
 												Required:            true,
 												CustomType:          supertypes.Int64Type{},
+											},
+										},
+									},
+									"issue_type": schema.SingleNestedAttribute{
+										MarkdownDescription: "Issue type is (or is not) `value`.",
+										Optional:            true,
+										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemConditionsItemIssueType](ctx),
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("age_comparison"), path.MatchRelative().AtParent().AtName("assigned_to"), path.MatchRelative().AtParent().AtName("issue_category"), path.MatchRelative().AtParent().AtName("issue_occurrences"), path.MatchRelative().AtParent().AtName("issue_priority_deescalating"), path.MatchRelative().AtParent().AtName("issue_priority_greater_or_equal"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_frequency_percent"), path.MatchRelative().AtParent().AtName("percent_sessions_count"), path.MatchRelative().AtParent().AtName("percent_sessions_percent"), path.MatchRelative().AtParent().AtName("event_attribute"), path.MatchRelative().AtParent().AtName("tagged_event"), path.MatchRelative().AtParent().AtName("latest_release"), path.MatchRelative().AtParent().AtName("latest_adopted_release"), path.MatchRelative().AtParent().AtName("level")),
+										},
+										Attributes: map[string]schema.Attribute{
+											"value": schema.StringAttribute{
+												MarkdownDescription: "The issue type slug (e.g. `performance_large_http_payload`).",
+												Required:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"include": schema.BoolAttribute{
+												MarkdownDescription: "If `true`, matches when the issue type equals `value`. If `false`, matches when it does not equal `value`.",
+												Required:            true,
+												CustomType:          supertypes.BoolType{},
 											},
 										},
 									},
@@ -1136,6 +1267,7 @@ type AlertResourceModelActionFiltersItemConditionsItem struct {
 	LatestRelease                 supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemLatestRelease]                 `tfsdk:"latest_release"`
 	LatestAdoptedRelease          supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemLatestAdoptedRelease]          `tfsdk:"latest_adopted_release"`
 	Level                         supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemLevel]                         `tfsdk:"level"`
+	IssueType                     supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemIssueType]                     `tfsdk:"issue_type"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemAgeComparison struct {
@@ -1179,14 +1311,30 @@ type AlertResourceModelActionFiltersItemConditionsItemEventUniqueUserFrequencyCo
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCount struct {
-	Value    supertypes.Int64Value  `tfsdk:"value"`
-	Interval supertypes.StringValue `tfsdk:"interval"`
+	Value    supertypes.Int64Value                                                                                                       `tfsdk:"value"`
+	Filters  supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem]         `tfsdk:"filters"`
+	Interval supertypes.StringValue                                                                                                      `tfsdk:"interval"`
+}
+
+type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem struct {
+	Key       supertypes.StringValue `tfsdk:"key"`
+	Attribute supertypes.StringValue `tfsdk:"attribute"`
+	Match     supertypes.StringValue `tfsdk:"match"`
+	Value     supertypes.StringValue `tfsdk:"value"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercent struct {
-	Value              supertypes.Int64Value  `tfsdk:"value"`
-	Interval           supertypes.StringValue `tfsdk:"interval"`
-	ComparisonInterval supertypes.StringValue `tfsdk:"comparison_interval"`
+	Value              supertypes.Int64Value                                                                                                          `tfsdk:"value"`
+	Filters            supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem]           `tfsdk:"filters"`
+	Interval           supertypes.StringValue                                                                                                         `tfsdk:"interval"`
+	ComparisonInterval supertypes.StringValue                                                                                                         `tfsdk:"comparison_interval"`
+}
+
+type AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem struct {
+	Key       supertypes.StringValue `tfsdk:"key"`
+	Attribute supertypes.StringValue `tfsdk:"attribute"`
+	Match     supertypes.StringValue `tfsdk:"match"`
+	Value     supertypes.StringValue `tfsdk:"value"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsCount struct {
@@ -1195,9 +1343,17 @@ type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsCount struc
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercent struct {
-	Value              supertypes.Int64Value  `tfsdk:"value"`
-	Interval           supertypes.StringValue `tfsdk:"interval"`
-	ComparisonInterval supertypes.StringValue `tfsdk:"comparison_interval"`
+	Value              supertypes.Int64Value                                                                                                              `tfsdk:"value"`
+	Filters            supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem]               `tfsdk:"filters"`
+	Interval           supertypes.StringValue                                                                                                              `tfsdk:"interval"`
+	ComparisonInterval supertypes.StringValue                                                                                                              `tfsdk:"comparison_interval"`
+}
+
+type AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem struct {
+	Key       supertypes.StringValue `tfsdk:"key"`
+	Attribute supertypes.StringValue `tfsdk:"attribute"`
+	Match     supertypes.StringValue `tfsdk:"match"`
+	Value     supertypes.StringValue `tfsdk:"value"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemEventAttribute struct {
@@ -1224,6 +1380,11 @@ type AlertResourceModelActionFiltersItemConditionsItemLatestAdoptedRelease struc
 type AlertResourceModelActionFiltersItemConditionsItemLevel struct {
 	Match supertypes.StringValue `tfsdk:"match"`
 	Level supertypes.Int64Value  `tfsdk:"level"`
+}
+
+type AlertResourceModelActionFiltersItemConditionsItemIssueType struct {
+	Value   supertypes.StringValue `tfsdk:"value"`
+	Include supertypes.BoolValue   `tfsdk:"include"`
 }
 
 type AlertResourceModelActionFiltersItemActionsItem struct {

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -167,8 +167,21 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 					return nil, diags
 				}
 
+				inFrequencyCountFilters := inEventFrequencyCount.Filters.DiagsGet(ctx, diags)
+				if diags.HasError() {
+					return nil, diags
+				}
+
 				var outEventFrequencyCount apiclient.OrganizationWorkflowActionFilterConditionEventFrequencyCount
 				outEventFrequencyCount.Comparison.Value = inEventFrequencyCount.Value.Get()
+				outEventFrequencyCount.Comparison.Filters = lo.ToPtr(lo.Map(inFrequencyCountFilters, func(inFilter *AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem, _ int) apiclient.OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter {
+					return apiclient.OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter{
+						Attribute: inFilter.Attribute.GetPtr(),
+						Key:       inFilter.Key.GetPtr(),
+						Match:     inFilter.Match.GetPtr(),
+						Value:     inFilter.Value.GetPtr(),
+					}
+				}))
 				outEventFrequencyCount.Comparison.Interval = inEventFrequencyCount.Interval.Get()
 				outEventFrequencyCount.ConditionResult = true
 
@@ -183,8 +196,21 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 					return nil, diags
 				}
 
+				inFrequencyPercentFilters := inEventFrequencyPercent.Filters.DiagsGet(ctx, diags)
+				if diags.HasError() {
+					return nil, diags
+				}
+
 				var outEventFrequencyPercent apiclient.OrganizationWorkflowActionFilterConditionEventFrequencyPercent
 				outEventFrequencyPercent.Comparison.Value = inEventFrequencyPercent.Value.Get()
+				outEventFrequencyPercent.Comparison.Filters = lo.ToPtr(lo.Map(inFrequencyPercentFilters, func(inFilter *AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem, _ int) apiclient.OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter {
+					return apiclient.OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter{
+						Attribute: inFilter.Attribute.GetPtr(),
+						Key:       inFilter.Key.GetPtr(),
+						Match:     inFilter.Match.GetPtr(),
+						Value:     inFilter.Value.GetPtr(),
+					}
+				}))
 				outEventFrequencyPercent.Comparison.Interval = inEventFrequencyPercent.Interval.Get()
 				outEventFrequencyPercent.Comparison.ComparisonInterval = inEventFrequencyPercent.ComparisonInterval.Get()
 				outEventFrequencyPercent.ConditionResult = true
@@ -216,8 +242,21 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 					return nil, diags
 				}
 
+				inSessionsPercentFilters := inPercentSessionsPercent.Filters.DiagsGet(ctx, diags)
+				if diags.HasError() {
+					return nil, diags
+				}
+
 				var outPercentSessionsPercent apiclient.OrganizationWorkflowActionFilterConditionPercentSessionsPercent
 				outPercentSessionsPercent.Comparison.Value = inPercentSessionsPercent.Value.Get()
+				outPercentSessionsPercent.Comparison.Filters = lo.ToPtr(lo.Map(inSessionsPercentFilters, func(inFilter *AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem, _ int) apiclient.OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter {
+					return apiclient.OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilter{
+						Attribute: inFilter.Attribute.GetPtr(),
+						Key:       inFilter.Key.GetPtr(),
+						Match:     inFilter.Match.GetPtr(),
+						Value:     inFilter.Value.GetPtr(),
+					}
+				}))
 				outPercentSessionsPercent.Comparison.Interval = inPercentSessionsPercent.Interval.Get()
 				outPercentSessionsPercent.Comparison.ComparisonInterval = inPercentSessionsPercent.ComparisonInterval.Get()
 				outPercentSessionsPercent.ConditionResult = true
@@ -236,7 +275,7 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				var outEventAttribute apiclient.OrganizationWorkflowActionFilterConditionEventAttribute
 				outEventAttribute.Comparison.Attribute = inEventAttribute.Attribute.Get()
 				outEventAttribute.Comparison.Match = inEventAttribute.Match.Get()
-				outEventAttribute.Comparison.Value = inEventAttribute.Value.Get()
+				outEventAttribute.Comparison.Value = inEventAttribute.Value.GetPtr()
 				outEventAttribute.ConditionResult = true
 
 				if err := outCondition.FromOrganizationWorkflowActionFilterConditionEventAttribute(outEventAttribute); err != nil {
@@ -300,6 +339,22 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				outLevel.ConditionResult = true
 
 				if err := outCondition.FromOrganizationWorkflowActionFilterConditionLevel(outLevel); err != nil {
+					diags.AddError("Failed to create condition", err.Error())
+					return nil, diags
+				}
+
+			case inCondition.IssueType.IsKnown():
+				inIssueType := inCondition.IssueType.DiagsGet(ctx, diags)
+				if diags.HasError() {
+					return nil, diags
+				}
+
+				var outIssueType apiclient.OrganizationWorkflowActionFilterConditionIssueType
+				outIssueType.Comparison.Value = inIssueType.Value.Get()
+				outIssueType.Comparison.Include = inIssueType.Include.Get()
+				outIssueType.ConditionResult = true
+
+				if err := outCondition.FromOrganizationWorkflowActionFilterConditionIssueType(outIssueType); err != nil {
 					diags.AddError("Failed to create condition", err.Error())
 					return nil, diags
 				}
@@ -788,6 +843,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				LatestRelease:                 supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemConditionsItemLatestRelease](ctx),
 				LatestAdoptedRelease:          supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemConditionsItemLatestAdoptedRelease](ctx),
 				Level:                         supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemConditionsItemLevel](ctx),
+				IssueType:                     supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemConditionsItemIssueType](ctx),
 			}
 
 			conditionValue, err := condition.ValueByDiscriminator()
@@ -871,6 +927,19 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				eventFrequencyCount.Value = supertypes.NewInt64Value(conditionValue.Comparison.Value)
 				eventFrequencyCount.Interval = supertypes.NewStringValue(conditionValue.Comparison.Interval)
 
+				outFrequencyCountFilters := []AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem{}
+				if conditionValue.Comparison.Filters != nil {
+					for _, filter := range *conditionValue.Comparison.Filters {
+						outFrequencyCountFilters = append(outFrequencyCountFilters, AlertResourceModelActionFiltersItemConditionsItemEventFrequencyCountFiltersItem{
+							Attribute: supertypes.NewStringPointerValueOrNull(filter.Attribute),
+							Key:       supertypes.NewStringPointerValueOrNull(filter.Key),
+							Match:     supertypes.NewStringPointerValueOrNull(filter.Match),
+							Value:     supertypes.NewStringPointerValueOrNull(filter.Value),
+						})
+					}
+				}
+				eventFrequencyCount.Filters = supertypes.NewListNestedObjectValueOfValueSlice(ctx, outFrequencyCountFilters)
+
 				outCondition.EventFrequencyCount = supertypes.NewSingleNestedObjectValueOf(ctx, &eventFrequencyCount)
 
 			case apiclient.OrganizationWorkflowActionFilterConditionEventFrequencyPercent:
@@ -878,6 +947,19 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				eventFrequencyPercent.Value = supertypes.NewInt64Value(conditionValue.Comparison.Value)
 				eventFrequencyPercent.Interval = supertypes.NewStringValue(conditionValue.Comparison.Interval)
 				eventFrequencyPercent.ComparisonInterval = supertypes.NewStringValue(conditionValue.Comparison.ComparisonInterval)
+
+				outFrequencyPercentFilters := []AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem{}
+				if conditionValue.Comparison.Filters != nil {
+					for _, filter := range *conditionValue.Comparison.Filters {
+						outFrequencyPercentFilters = append(outFrequencyPercentFilters, AlertResourceModelActionFiltersItemConditionsItemEventFrequencyPercentFiltersItem{
+							Attribute: supertypes.NewStringPointerValueOrNull(filter.Attribute),
+							Key:       supertypes.NewStringPointerValueOrNull(filter.Key),
+							Match:     supertypes.NewStringPointerValueOrNull(filter.Match),
+							Value:     supertypes.NewStringPointerValueOrNull(filter.Value),
+						})
+					}
+				}
+				eventFrequencyPercent.Filters = supertypes.NewListNestedObjectValueOfValueSlice(ctx, outFrequencyPercentFilters)
 
 				outCondition.EventFrequencyPercent = supertypes.NewSingleNestedObjectValueOf(ctx, &eventFrequencyPercent)
 
@@ -894,13 +976,26 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				percentSessionsPercent.Interval = supertypes.NewStringValue(conditionValue.Comparison.Interval)
 				percentSessionsPercent.ComparisonInterval = supertypes.NewStringValue(conditionValue.Comparison.ComparisonInterval)
 
+				outSessionsPercentFilters := []AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem{}
+				if conditionValue.Comparison.Filters != nil {
+					for _, filter := range *conditionValue.Comparison.Filters {
+						outSessionsPercentFilters = append(outSessionsPercentFilters, AlertResourceModelActionFiltersItemConditionsItemPercentSessionsPercentFiltersItem{
+							Attribute: supertypes.NewStringPointerValueOrNull(filter.Attribute),
+							Key:       supertypes.NewStringPointerValueOrNull(filter.Key),
+							Match:     supertypes.NewStringPointerValueOrNull(filter.Match),
+							Value:     supertypes.NewStringPointerValueOrNull(filter.Value),
+						})
+					}
+				}
+				percentSessionsPercent.Filters = supertypes.NewListNestedObjectValueOfValueSlice(ctx, outSessionsPercentFilters)
+
 				outCondition.PercentSessionsPercent = supertypes.NewSingleNestedObjectValueOf(ctx, &percentSessionsPercent)
 
 			case apiclient.OrganizationWorkflowActionFilterConditionEventAttribute:
 				var eventAttribute AlertResourceModelActionFiltersItemConditionsItemEventAttribute
 				eventAttribute.Attribute = supertypes.NewStringValue(conditionValue.Comparison.Attribute)
 				eventAttribute.Match = supertypes.NewStringValue(conditionValue.Comparison.Match)
-				eventAttribute.Value = supertypes.NewStringValue(conditionValue.Comparison.Value)
+				eventAttribute.Value = supertypes.NewStringPointerValueOrNull(conditionValue.Comparison.Value)
 
 				outCondition.EventAttribute = supertypes.NewSingleNestedObjectValueOf(ctx, &eventAttribute)
 
@@ -931,6 +1026,13 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				level.Level = supertypes.NewInt64Value(conditionValue.Comparison.Level)
 
 				outCondition.Level = supertypes.NewSingleNestedObjectValueOf(ctx, &level)
+
+			case apiclient.OrganizationWorkflowActionFilterConditionIssueType:
+				var issueType AlertResourceModelActionFiltersItemConditionsItemIssueType
+				issueType.Value = supertypes.NewStringValue(conditionValue.Comparison.Value)
+				issueType.Include = supertypes.NewBoolValue(conditionValue.Comparison.Include)
+
+				outCondition.IssueType = supertypes.NewSingleNestedObjectValueOf(ctx, &issueType)
 			}
 
 			outConditions = append(outConditions, outCondition)

--- a/internal/provider/resource_alert_test.go
+++ b/internal/provider/resource_alert_test.go
@@ -403,6 +403,53 @@ func testAccAlertResourceConfig(teamName, projectName, monitorName, name, opsgen
 								match = "eq"
 								level = 50
 							}
+						},
+						{
+							issue_type = {
+								value   = "performance_large_http_payload"
+								include = false
+							}
+						},
+						{
+							event_attribute = {
+								attribute = "message"
+								match     = "is"
+							}
+						},
+						{
+							event_attribute = {
+								attribute = "message"
+								match     = "ns"
+							}
+						},
+						{
+							event_frequency_count = {
+								value = 10
+								filters = [
+									{ attribute = "message", match = "co", value = "error" }
+								]
+								interval = "1m"
+							}
+						},
+						{
+							event_frequency_percent = {
+								value = 50
+								filters = [
+									{ key = "tag", match = "eq", value = "test" }
+								]
+								interval  = "1h"
+								comparison_interval = "1w"
+							}
+						},
+						{
+							percent_sessions_percent = {
+								value = 25
+								filters = [
+									{ attribute = "message", match = "eq", value = "crash" }
+								]
+								interval            = "1h"
+								comparison_interval = "1w"
+							}
 						}
 					]
 					actions = [

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -331,6 +331,48 @@ export default {
                   validators: ["int64validator.AtLeast(1)"],
                 },
                 {
+                  name: "filters",
+                  type: "list_nested",
+                  description:
+                    "A list of additional sub-filters to evaluate before the alert will fire.",
+                  computedOptionalRequired: "computed_optional",
+                  attributes: [
+                    {
+                      name: "key",
+                      type: "string",
+                      description:
+                        "The key of the filter. Conflicts with `attribute`.",
+                      computedOptionalRequired: "optional",
+                      validators: [
+                        `stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("attribute"))`,
+                      ],
+                    },
+                    {
+                      name: "attribute",
+                      type: "string",
+                      description:
+                        "The attribute of the filter. Conflicts with `key`.",
+                      computedOptionalRequired: "optional",
+                      validators: [
+                        `stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key"))`,
+                      ],
+                    },
+                    {
+                      name: "match",
+                      type: "string",
+                      description: "The match type of the filter.",
+                      computedOptionalRequired: "optional",
+                      enum: "sentrydata.MatchTypeIds",
+                    },
+                    {
+                      name: "value",
+                      type: "string",
+                      description: "The value of the filter.",
+                      computedOptionalRequired: "optional",
+                    },
+                  ],
+                },
+                {
                   name: "interval",
                   type: "string",
                   description:
@@ -353,6 +395,48 @@ export default {
                     "A positive integer representing the number of events in an issue that must come in before the alert will fire.",
                   computedOptionalRequired: "required",
                   validators: ["int64validator.AtLeast(1)"],
+                },
+                {
+                  name: "filters",
+                  type: "list_nested",
+                  description:
+                    "A list of additional sub-filters to evaluate before the alert will fire.",
+                  computedOptionalRequired: "computed_optional",
+                  attributes: [
+                    {
+                      name: "key",
+                      type: "string",
+                      description:
+                        "The key of the filter. Conflicts with `attribute`.",
+                      computedOptionalRequired: "optional",
+                      validators: [
+                        `stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("attribute"))`,
+                      ],
+                    },
+                    {
+                      name: "attribute",
+                      type: "string",
+                      description:
+                        "The attribute of the filter. Conflicts with `key`.",
+                      computedOptionalRequired: "optional",
+                      validators: [
+                        `stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key"))`,
+                      ],
+                    },
+                    {
+                      name: "match",
+                      type: "string",
+                      description: "The match type of the filter.",
+                      computedOptionalRequired: "optional",
+                      enum: "sentrydata.MatchTypeIds",
+                    },
+                    {
+                      name: "value",
+                      type: "string",
+                      description: "The value of the filter.",
+                      computedOptionalRequired: "optional",
+                    },
+                  ],
                 },
                 {
                   name: "interval",
@@ -410,6 +494,48 @@ export default {
                   validators: ["int64validator.AtLeast(1)"],
                 },
                 {
+                  name: "filters",
+                  type: "list_nested",
+                  description:
+                    "A list of additional sub-filters to evaluate before the alert will fire.",
+                  computedOptionalRequired: "computed_optional",
+                  attributes: [
+                    {
+                      name: "key",
+                      type: "string",
+                      description:
+                        "The key of the filter. Conflicts with `attribute`.",
+                      computedOptionalRequired: "optional",
+                      validators: [
+                        `stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("attribute"))`,
+                      ],
+                    },
+                    {
+                      name: "attribute",
+                      type: "string",
+                      description:
+                        "The attribute of the filter. Conflicts with `key`.",
+                      computedOptionalRequired: "optional",
+                      validators: [
+                        `stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("key"))`,
+                      ],
+                    },
+                    {
+                      name: "match",
+                      type: "string",
+                      description: "The match type of the filter.",
+                      computedOptionalRequired: "optional",
+                      enum: "sentrydata.MatchTypeIds",
+                    },
+                    {
+                      name: "value",
+                      type: "string",
+                      description: "The value of the filter.",
+                      computedOptionalRequired: "optional",
+                    },
+                  ],
+                },
+                {
                   name: "interval",
                   type: "string",
                   description:
@@ -447,8 +573,12 @@ export default {
                 {
                   name: "value",
                   type: "string",
-                  description: "The value to compare against.",
-                  computedOptionalRequired: "required",
+                  description:
+                    "The value to compare against. Not required when `match` is `is` or `ns`.",
+                  computedOptionalRequired: "optional",
+                  validators: [
+                    `fstringvalidator.NullIfAttributeIsOneOf(path.MatchRelative().AtParent().AtName("match"), []attr.Value{supertypes.NewStringValue("is"), supertypes.NewStringValue("ns")})`,
+                  ],
                 },
               ],
             },
@@ -535,6 +665,28 @@ export default {
                   name: "level",
                   type: "int",
                   description: "The level to compare against.",
+                  computedOptionalRequired: "required",
+                },
+              ],
+            },
+            {
+              name: "issue_type",
+              type: "single_nested",
+              description: "Issue type is (or is not) `value`.",
+              computedOptionalRequired: "optional",
+              attributes: [
+                {
+                  name: "value",
+                  type: "string",
+                  description:
+                    "The issue type slug (e.g. `performance_large_http_payload`).",
+                  computedOptionalRequired: "required",
+                },
+                {
+                  name: "include",
+                  type: "bool",
+                  description:
+                    "If `true`, matches when the issue type equals `value`. If `false`, matches when it does not equal `value`.",
                   computedOptionalRequired: "required",
                 },
               ],

--- a/internal/sentrydata/generate.py
+++ b/internal/sentrydata/generate.py
@@ -190,6 +190,10 @@ def parse_rules_match() -> dict[str, ResultData[Any]]:
                     github_url=data.github_url,
                     result=[],
                 )
+                out["MatchTypeIds"] = ResultData(
+                    github_url=data.github_url,
+                    result=[],
+                )
                 out["MatchTypeNameToId"] = ResultData(
                     github_url=data.github_url,
                     result=OrderedDict(),
@@ -205,6 +209,7 @@ def parse_rules_match() -> dict[str, ResultData[Any]]:
                             value=ast.Constant(value=value),
                         ) if id.isupper():
                             out["MatchTypes"].result.append(id)
+                            out["MatchTypeIds"].result.append(value)
                             out["MatchTypeNameToId"].result[id] = value
                             out["MatchTypeIdToName"].result[value] = id
                         case _:

--- a/internal/sentrydata/sentrydata.go
+++ b/internal/sentrydata/sentrydata.go
@@ -154,6 +154,26 @@ var MatchTypes = []string{
 }
 
 // https://github.com/getsentry/sentry/blob/master/src/sentry/rules/match.py
+var MatchTypeIds = []string{
+	"co",
+	"ew",
+	"eq",
+	"gte",
+	"gt",
+	"is",
+	"in",
+	"lte",
+	"lt",
+	"nc",
+	"new",
+	"ne",
+	"ns",
+	"nsw",
+	"nin",
+	"sw",
+}
+
+// https://github.com/getsentry/sentry/blob/master/src/sentry/rules/match.py
 var MatchTypeNameToId = map[string]string{
 	"CONTAINS":         "co",
 	"ENDS_WITH":        "ew",


### PR DESCRIPTION
…filters to frequency conditions

Three fixes for sentry_alert action_filter conditions:

- Add `issue_type` discriminator and schema: importing or reading an alert with an issue_type condition no longer crashes with "unknown discriminator value: issue_type". Supports `value` (slug) and `include` (is/is-not).

- Fix `event_attribute` value for is/ns match types: `value` is now optional and null when `match` is `is` or `ns`, matching the Sentry backend schema. Previously these conditions could not be imported or expressed in config.

- Add `filters` sub-field to `event_frequency_count`, `event_frequency_percent`, and `percent_sessions_percent`: conditions saved with sub-filters in the UI were previously silently dropped from state on every plan.