### PR TITLE
fix(issue-alert): stabilize conditions_v2/filters_v2/actions_v2 list order after API read

### DIFF
--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -1464,6 +1464,14 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 			return
 		}
 	} else if !m.ConditionsV2.IsNull() {
+		var priorConditions []IssueAlertConditionModel
+		if !m.ConditionsV2.IsUnknown() {
+			diags.Append(m.ConditionsV2.ElementsAs(ctx, &priorConditions, false)...)
+			if diags.HasError() {
+				return
+			}
+		}
+
 		conditions := lo.Map(alert.Conditions, func(condition apiclient.ProjectRuleCondition, _ int) IssueAlertConditionModel {
 			var conditionModel IssueAlertConditionModel
 			diags.Append(conditionModel.Fill(ctx, condition)...)
@@ -1473,6 +1481,8 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 		if diags.HasError() {
 			return
 		}
+
+		conditions = reorderToMatchPrior(priorConditions, conditions, issueAlertConditionModelKey)
 
 		conditionsV2, d := types.ListValueFrom(ctx, issueAlertConditionV2ElemType, conditions)
 		diags.Append(d...)
@@ -1489,6 +1499,14 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 			diags.AddError("Invalid filters", err.Error())
 		}
 	} else if !m.FiltersV2.IsNull() {
+		var priorFilters []IssueAlertFilterModel
+		if !m.FiltersV2.IsUnknown() {
+			diags.Append(m.FiltersV2.ElementsAs(ctx, &priorFilters, false)...)
+			if diags.HasError() {
+				return
+			}
+		}
+
 		filters := lo.Map(alert.Filters, func(filter apiclient.ProjectRuleFilter, _ int) IssueAlertFilterModel {
 			var filterModel IssueAlertFilterModel
 			diags.Append(filterModel.Fill(ctx, filter)...)
@@ -1498,6 +1516,8 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 		if diags.HasError() {
 			return
 		}
+
+		filters = reorderToMatchPrior(priorFilters, filters, issueAlertFilterModelKey)
 
 		filtersV2, d := types.ListValueFrom(ctx, issueAlertFilterV2ElemType, filters)
 		diags.Append(d...)
@@ -1514,6 +1534,14 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 			diags.AddError("Invalid actions", err.Error())
 		}
 	} else if !m.ActionsV2.IsNull() {
+		var priorActions []IssueAlertActionModel
+		if !m.ActionsV2.IsUnknown() {
+			diags.Append(m.ActionsV2.ElementsAs(ctx, &priorActions, false)...)
+			if diags.HasError() {
+				return
+			}
+		}
+
 		actions := lo.Map(alert.Actions, func(action apiclient.ProjectRuleAction, _ int) IssueAlertActionModel {
 			var actionModel IssueAlertActionModel
 			diags.Append(actionModel.Fill(ctx, action)...)
@@ -1523,6 +1551,8 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 		if diags.HasError() {
 			return
 		}
+
+		actions = reorderToMatchPrior(priorActions, actions, issueAlertActionModelKey)
 
 		actionsV2, d := types.ListValueFrom(ctx, issueAlertActionV2ElemType, actions)
 		diags.Append(d...)

--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -1457,8 +1457,17 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 	}
 
 	if !m.Conditions.IsNull() {
-		if conditions, err := json.Marshal(alert.Conditions); err == nil {
-			m.Conditions = sentrytypes.NewLossyJsonValue(string(conditions))
+		apiConditions := lo.Map(alert.Conditions, func(c apiclient.ProjectRuleCondition, _ int) json.RawMessage {
+			b, _ := json.Marshal(c)
+			return b
+		})
+		var priorConditions []json.RawMessage
+		if !m.Conditions.IsUnknown() {
+			_ = json.Unmarshal([]byte(m.Conditions.ValueString()), &priorConditions)
+		}
+		apiConditions = reorderToMatchPrior(priorConditions, apiConditions, legacyJsonItemKey)
+		if b, err := json.Marshal(apiConditions); err == nil {
+			m.Conditions = sentrytypes.NewLossyJsonValue(string(b))
 		} else {
 			diags.AddError("Invalid conditions", err.Error())
 			return
@@ -1493,8 +1502,17 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 	}
 
 	if !m.Filters.IsNull() {
-		if filters, err := json.Marshal(alert.Filters); err == nil {
-			m.Filters = sentrytypes.NewLossyJsonValue(string(filters))
+		apiFilters := lo.Map(alert.Filters, func(f apiclient.ProjectRuleFilter, _ int) json.RawMessage {
+			b, _ := json.Marshal(f)
+			return b
+		})
+		var priorFilters []json.RawMessage
+		if !m.Filters.IsUnknown() {
+			_ = json.Unmarshal([]byte(m.Filters.ValueString()), &priorFilters)
+		}
+		apiFilters = reorderToMatchPrior(priorFilters, apiFilters, legacyJsonItemKey)
+		if b, err := json.Marshal(apiFilters); err == nil {
+			m.Filters = sentrytypes.NewLossyJsonValue(string(b))
 		} else {
 			diags.AddError("Invalid filters", err.Error())
 		}
@@ -1528,10 +1546,19 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 	}
 
 	if !m.Actions.IsNull() {
-		if actions, err := json.Marshal(alert.Actions); err == nil && len(actions) > 0 {
-			m.Actions = sentrytypes.NewLossyJsonValue(string(actions))
-		} else {
+		apiActions := lo.Map(alert.Actions, func(a apiclient.ProjectRuleAction, _ int) json.RawMessage {
+			b, _ := json.Marshal(a)
+			return b
+		})
+		var priorActions []json.RawMessage
+		if !m.Actions.IsUnknown() {
+			_ = json.Unmarshal([]byte(m.Actions.ValueString()), &priorActions)
+		}
+		apiActions = reorderToMatchPrior(priorActions, apiActions, legacyJsonItemKey)
+		if b, err := json.Marshal(apiActions); err != nil {
 			diags.AddError("Invalid actions", err.Error())
+		} else {
+			m.Actions = sentrytypes.NewLossyJsonValue(string(b))
 		}
 	} else if !m.ActionsV2.IsNull() {
 		var priorActions []IssueAlertActionModel

--- a/internal/provider/model_issue_alert_ordering.go
+++ b/internal/provider/model_issue_alert_ordering.go
@@ -1,0 +1,208 @@
+package provider
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jianyuan/terraform-provider-sentry/internal/sentrytypes"
+)
+
+// reorderToMatchPrior reorders incoming items to match the order of prior items by key.
+// Items in incoming that have no matching prior key are appended at the end in their
+// original order. Items in prior with no match in incoming are silently skipped.
+//
+// This is used after reading from the Sentry API to stabilize list order: the API may
+// return conditions/filters/actions in a different order than was planned or previously
+// stored, causing "Provider produced inconsistent result after apply" errors.
+func reorderToMatchPrior[T any, K comparable](prior, incoming []T, key func(T) K) []T {
+	if len(prior) == 0 {
+		return incoming
+	}
+
+	type entry struct {
+		item T
+		used bool
+	}
+
+	pool := make(map[K][]*entry)
+	entries := make([]*entry, len(incoming))
+	for i, item := range incoming {
+		e := &entry{item: item}
+		entries[i] = e
+		k := key(item)
+		pool[k] = append(pool[k], e)
+	}
+
+	result := make([]T, 0, len(incoming))
+	for _, p := range prior {
+		k := key(p)
+		for _, e := range pool[k] {
+			if !e.used {
+				result = append(result, e.item)
+				e.used = true
+				break
+			}
+		}
+	}
+	for _, e := range entries {
+		if !e.used {
+			result = append(result, e.item)
+		}
+	}
+	return result
+}
+
+func issueAlertConditionModelKey(m IssueAlertConditionModel) string {
+	switch {
+	case m.FirstSeenEvent != nil:
+		return "first_seen_event"
+	case m.RegressionEvent != nil:
+		return "regression_event"
+	case m.ReappearedEvent != nil:
+		return "reappeared_event"
+	case m.NewHighPriorityIssue != nil:
+		return "new_high_priority_issue"
+	case m.ExistingHighPriorityIssue != nil:
+		return "existing_high_priority_issue"
+	case m.EventFrequency != nil:
+		f := m.EventFrequency
+		return fmt.Sprintf("event_frequency\x00%s\x00%s\x00%d\x00%s",
+			f.ComparisonType.ValueString(), f.Interval.ValueString(),
+			f.Value.ValueInt64(), f.ComparisonInterval.ValueString())
+	case m.EventUniqueUserFrequency != nil:
+		f := m.EventUniqueUserFrequency
+		return fmt.Sprintf("event_unique_user_frequency\x00%s\x00%s\x00%d\x00%s",
+			f.ComparisonType.ValueString(), f.Interval.ValueString(),
+			f.Value.ValueInt64(), f.ComparisonInterval.ValueString())
+	case m.EventFrequencyPercent != nil:
+		f := m.EventFrequencyPercent
+		return fmt.Sprintf("event_frequency_percent\x00%s\x00%s\x00%g\x00%s",
+			f.ComparisonType.ValueString(), f.Interval.ValueString(),
+			f.Value.ValueFloat64(), f.ComparisonInterval.ValueString())
+	default:
+		return ""
+	}
+}
+
+func issueAlertFilterModelKey(m IssueAlertFilterModel) string {
+	switch {
+	case m.AgeComparison != nil:
+		f := m.AgeComparison
+		return fmt.Sprintf("age_comparison\x00%s\x00%d\x00%s",
+			f.ComparisonType.ValueString(), f.Value.ValueInt64(), f.Time.ValueString())
+	case m.IssueOccurrences != nil:
+		return fmt.Sprintf("issue_occurrences\x00%d", m.IssueOccurrences.Value.ValueInt64())
+	case m.AssignedTo != nil:
+		f := m.AssignedTo
+		return fmt.Sprintf("assigned_to\x00%s\x00%s",
+			f.TargetType.ValueString(), f.TargetIdentifier.ValueString())
+	case m.LatestAdoptedRelease != nil:
+		f := m.LatestAdoptedRelease
+		return fmt.Sprintf("latest_adopted_release\x00%s\x00%s\x00%s",
+			f.OldestOrNewest.ValueString(), f.OlderOrNewer.ValueString(), f.Environment.ValueString())
+	case m.LatestRelease != nil:
+		return "latest_release"
+	case m.IssueCategory != nil:
+		return fmt.Sprintf("issue_category\x00%s", m.IssueCategory.Value.ValueString())
+	case m.EventAttribute != nil:
+		f := m.EventAttribute
+		return fmt.Sprintf("event_attribute\x00%s\x00%s\x00%s",
+			f.Attribute.ValueString(), f.Match.ValueString(), f.Value.ValueString())
+	case m.TaggedEvent != nil:
+		f := m.TaggedEvent
+		return fmt.Sprintf("tagged_event\x00%s\x00%s\x00%s",
+			f.Key.ValueString(), f.Match.ValueString(), f.Value.ValueString())
+	case m.Level != nil:
+		f := m.Level
+		return fmt.Sprintf("level\x00%s\x00%s", f.Match.ValueString(), f.Level.ValueString())
+	default:
+		return ""
+	}
+}
+
+func issueAlertActionModelKey(m IssueAlertActionModel) string {
+	switch {
+	case m.NotifyEmail != nil:
+		f := m.NotifyEmail
+		return fmt.Sprintf("notify_email\x00%s\x00%s\x00%s",
+			f.TargetType.ValueString(), f.TargetIdentifier.ValueString(), f.FallthroughType.ValueString())
+	case m.NotifyEvent != nil:
+		return "notify_event"
+	case m.NotifyEventService != nil:
+		return fmt.Sprintf("notify_event_service\x00%s", m.NotifyEventService.Service.ValueString())
+	case m.NotifyEventSentryApp != nil:
+		return fmt.Sprintf("notify_event_sentry_app\x00%s", m.NotifyEventSentryApp.SentryAppInstallationUuid.ValueString())
+	case m.OpsgenieNotifyTeam != nil:
+		f := m.OpsgenieNotifyTeam
+		return fmt.Sprintf("opsgenie_notify_team\x00%s\x00%s\x00%s",
+			f.Account.ValueString(), f.Team.ValueString(), f.Priority.ValueString())
+	case m.PagerDutyNotifyService != nil:
+		f := m.PagerDutyNotifyService
+		return fmt.Sprintf("pagerduty_notify_service\x00%s\x00%s\x00%s",
+			f.Account.ValueString(), f.Service.ValueString(), f.Severity.ValueString())
+	case m.SlackNotifyService != nil:
+		f := m.SlackNotifyService
+		return fmt.Sprintf("slack_notify_service\x00%s\x00%s\x00%s",
+			f.Workspace.ValueString(), f.Channel.ValueString(), stringSetKey(f.Tags))
+	case m.MsTeamsNotifyService != nil:
+		f := m.MsTeamsNotifyService
+		return fmt.Sprintf("msteams_notify_service\x00%s\x00%s",
+			f.Team.ValueString(), f.Channel.ValueString())
+	case m.DiscordNotifyService != nil:
+		f := m.DiscordNotifyService
+		return fmt.Sprintf("discord_notify_service\x00%s\x00%s\x00%s",
+			f.Server.ValueString(), f.ChannelId.ValueString(), stringSetKey(f.Tags))
+	case m.JiraCreateTicket != nil:
+		f := m.JiraCreateTicket
+		return fmt.Sprintf("jira_create_ticket\x00%s\x00%s\x00%s",
+			f.Integration.ValueString(), f.Project.ValueString(), f.IssueType.ValueString())
+	case m.JiraServerCreateTicket != nil:
+		f := m.JiraServerCreateTicket
+		return fmt.Sprintf("jira_server_create_ticket\x00%s\x00%s\x00%s",
+			f.Integration.ValueString(), f.Project.ValueString(), f.IssueType.ValueString())
+	case m.GitHubCreateTicket != nil:
+		f := m.GitHubCreateTicket
+		return fmt.Sprintf("github_create_ticket\x00%s\x00%s\x00%s\x00%s",
+			f.Integration.ValueString(), f.Repo.ValueString(),
+			f.Assignee.ValueString(), typesSetKey(f.Labels))
+	case m.GitHubEnterpriseCreateTicket != nil:
+		f := m.GitHubEnterpriseCreateTicket
+		return fmt.Sprintf("github_enterprise_create_ticket\x00%s\x00%s\x00%s\x00%s",
+			f.Integration.ValueString(), f.Repo.ValueString(),
+			f.Assignee.ValueString(), typesSetKey(f.Labels))
+	case m.AzureDevopsCreateTicket != nil:
+		f := m.AzureDevopsCreateTicket
+		return fmt.Sprintf("azure_devops_create_ticket\x00%s\x00%s\x00%s",
+			f.Integration.ValueString(), f.Project.ValueString(), f.WorkItemType.ValueString())
+	default:
+		return ""
+	}
+}
+
+// stringSetKey produces a stable string key from a sentrytypes.StringSet.
+func stringSetKey(s sentrytypes.StringSet) string {
+	if s.IsNull() || s.IsUnknown() {
+		return ""
+	}
+	strs := make([]string, 0, len(s.Elements()))
+	for _, e := range s.Elements() {
+		strs = append(strs, e.String())
+	}
+	sort.Strings(strs)
+	return strings.Join(strs, ",")
+}
+
+// typesSetKey produces a stable string key from a types.Set.
+func typesSetKey(s types.Set) string {
+	if s.IsNull() || s.IsUnknown() {
+		return ""
+	}
+	strs := make([]string, 0, len(s.Elements()))
+	for _, e := range s.Elements() {
+		strs = append(strs, e.String())
+	}
+	sort.Strings(strs)
+	return strings.Join(strs, ",")
+}

--- a/internal/provider/model_issue_alert_ordering.go
+++ b/internal/provider/model_issue_alert_ordering.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -205,4 +206,18 @@ func typesSetKey(s types.Set) string {
 	}
 	sort.Strings(strs)
 	return strings.Join(strs, ",")
+}
+
+// legacyJsonItemKey extracts a stable identity key from a raw JSON object
+// by reading its "id" field. Used to reorder legacy conditions/filters/actions
+// JSON arrays to match prior state after an API read.
+func legacyJsonItemKey(raw json.RawMessage) string {
+	dec := json.NewDecoder(strings.NewReader(string(raw)))
+	dec.UseNumber()
+	var m map[string]interface{}
+	if err := dec.Decode(&m); err != nil {
+		return string(raw)
+	}
+	id, _ := m["id"].(string)
+	return id
 }

--- a/internal/provider/resource_issue_alert_unit_test.go
+++ b/internal/provider/resource_issue_alert_unit_test.go
@@ -234,3 +234,71 @@ func TestSlackChannel_SemanticEquals_ignoresHashPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestReorderToMatchPrior_preservesPriorOrder(t *testing.T) {
+	identity := func(s string) string { return s }
+
+	prior := []string{"a", "b", "c"}
+	incoming := []string{"c", "a", "b"}
+	got := reorderToMatchPrior(prior, incoming, identity)
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReorderToMatchPrior_appendsNewItems(t *testing.T) {
+	identity := func(s string) string { return s }
+
+	prior := []string{"a", "b"}
+	incoming := []string{"c", "b", "a"}
+	got := reorderToMatchPrior(prior, incoming, identity)
+	// prior items first in order, then unmatched "c"
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReorderToMatchPrior_handlesDuplicateTypes(t *testing.T) {
+	identity := func(s string) string { return s }
+
+	prior := []string{"x", "x", "y"}
+	incoming := []string{"y", "x", "x"}
+	got := reorderToMatchPrior(prior, incoming, identity)
+	want := []string{"x", "x", "y"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestReorderToMatchPrior_emptyPriorReturnsincoming(t *testing.T) {
+	identity := func(s string) string { return s }
+
+	prior := []string{}
+	incoming := []string{"c", "b", "a"}
+	got := reorderToMatchPrior(prior, incoming, identity)
+	if len(got) != len(incoming) {
+		t.Fatalf("len mismatch: got %v, want %v", got, incoming)
+	}
+	for i := range incoming {
+		if got[i] != incoming[i] {
+			t.Errorf("index %d: got %q, want %q", i, got[i], incoming[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #822.

The Sentry API can return `conditions`, `filters`, and `actions` in a different order than the user originally wrote them. For resources using the `conditions_v2`, `filters_v2`, and `actions_v2` block attributes, this caused **"Provider produced inconsistent result after apply"** errors on every plan/apply cycle.

### What changed

- Added `reorderToMatchPrior` — a generic helper that, after reading from the API, reorders the incoming items to match the order stored in prior state, using a stable key per item type. Items that appear in the API response but not in prior state are appended at the end in API order.
- In `IssueAlertModel.Fill()`, prior state is extracted before overwriting each of the three v2 lists, and the API response is reordered to match it.
- Key functions cover all known condition, filter, and action types; for types with configurable parameters (e.g. `event_frequency`, `slack_notify_service`) the key includes the distinguishing fields so two different instances of the same type are not conflated.
- 4 unit tests added for `reorderToMatchPrior`.

## Known limitation

This fix handles the common cases (API reorders a heterogeneous list, or returns duplicate same-type items in a different order). There is one edge case it does **not** resolve cleanly:

> If a user has **multiple conditions/filters/actions of the same type** with **identical parameters** and then **changes a parameter on exactly one of them**, the prior-state key for that item no longer matches the API response key. The reorder logic cannot find a match, appends the item at the end, and Terraform sees a different order than planned — producing a "Provider produced inconsistent result after apply" on that specific apply, leaving the resource in a stuck state.

**Example:** Two `event_frequency` conditions with `value = 100` and `value = 200`. User changes the first to `value = 150`. The prior key `event_frequency\x00count\x00...\x00100\x00...` no longer exists in the API response, so the reordered list comes back in a different order than Terraform expected.

**Workaround for affected users:** `terraform state rm <resource>` followed by `terraform import`.

This edge case was deliberately not addressed with a two-phase type-only fallback matcher because `sentry_issue_alert` is scheduled for deprecation in ~90 days (superseded by `sentry_alert`), so the complexity is not warranted. The fix resolves the vast majority of real-world occurrences of #822.

## Test plan

- [ ] `go test ./internal/provider/ -run TestReorderToMatchPrior` passes
- [ ] `go test ./internal/provider/ -run TestAccIssueAlert` passes end-to-end (requires Sentry API credentials)
- [ ] Plan/apply on an existing `sentry_issue_alert` with `conditions_v2` no longer shows drift after a no-op apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)