### PR TITLE
fix(resource/sentry_alert): sort alert trigger conditions

### DIFF
--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -3021,6 +3021,9 @@ components:
         - comparison
         - conditionResult
       properties:
+        id:
+          type: integer
+          x-go-type: json.Number
         type:
           type: string
         comparison:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -2110,6 +2110,7 @@ type OrganizationWorkflowTriggerLogicType string
 type OrganizationWorkflowTriggerCondition struct {
 	Comparison      OrganizationWorkflowTriggerCondition_Comparison `json:"comparison"`
 	ConditionResult bool                                            `json:"conditionResult"`
+	Id              *json.Number                                    `json:"id,omitempty"`
 	Type            string                                          `json:"type"`
 }
 

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -678,6 +678,14 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 		return diags
 	}
 
+	// NOTE: The API returns conditions in a random order, so we need to sort them by ID to ensure that the
+	// order is deterministic.
+	slices.SortFunc(triggers.Conditions, func(a, b apiclient.OrganizationWorkflowTriggerCondition) int {
+		aId := int(must.Get(a.Id.Int64()))
+		bId := int(must.Get(b.Id.Int64()))
+		return aId - bId
+	})
+
 	var triggerConditions []AlertResourceModelTriggerConditionsItem
 	for _, triggerCondition := range triggers.Conditions {
 		outTriggerCondition := AlertResourceModelTriggerConditionsItem{


### PR DESCRIPTION
The API may return alert trigger conditions in a random order. PR to sort them by ID.
