### PR TITLE
feat(alert): add legacy_trigger_conditions to surface unrecognized trigger types

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -871,6 +871,7 @@ resource "sentry_alert" "default" {
 ### Optional
 
 - `enabled` (Boolean) Whether the alert is enabled. Defaults to `true`.
+- `legacy_trigger_conditions` (List of String) ⚠️ The trigger condition types listed here are not natively supported by this provider and may be deprecated by Sentry in a future API version. Trigger condition types present on this alert that are not representable in `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`, `issue_resolution_change`). When omitted from config these will be removed on the next apply. Set explicitly to preserve them.
 
 ### Read-Only
 

--- a/examples/resources/sentry_alert/resource-28-legacy_trigger_conditions.tf
+++ b/examples/resources/sentry_alert/resource-28-legacy_trigger_conditions.tf
@@ -1,0 +1,43 @@
+resource "sentry_metric_monitor" "default" {
+  # ...
+}
+
+resource "sentry_alert" "legacy" {
+  organization = "my-organization"
+  name         = "My Alert (with legacy trigger conditions)"
+  environment  = "production"
+
+  monitor_ids       = [sentry_metric_monitor.default.id]
+  frequency_minutes = 1440
+
+  # All natively supported trigger condition types
+  trigger_conditions = [
+    { first_seen_event = {} },
+    { issue_resolved_trigger = {} },
+    { reappeared_event = {} },
+    { regression_event = {} },
+  ]
+
+  # Trigger condition types that are not configurable in the latest Sentry alerts
+  # UI similar to trigger_conditions. Set explicitly to preserve them;
+  # omit to remove them on the next apply.
+  legacy_trigger_conditions = [
+    "new_high_priority_issue",
+    "existing_high_priority_issue",
+  ]
+
+  action_filters = [
+    {
+      logic_type = "all"
+      conditions = []
+      actions = [
+        {
+          email = {
+            target_type      = "issue_owners"
+            fallthrough_type = "AllMembers"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrydata"
 	"github.com/jianyuan/terraform-provider-sentry/internal/tfutils"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
@@ -134,11 +133,6 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						},
 					},
 				},
-			},
-			"legacy_trigger_conditions": schema.ListAttribute{
-				ElementType:         types.StringType,
-				Optional:            true,
-				MarkdownDescription: "Trigger condition types present on this alert that are not configurable in the latest Sentry alerts UI similar to `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`). When omitted from config, any matching conditions returned by the API will be removed on the next apply.",
 			},
 			"action_filters": schema.ListNestedAttribute{
 				MarkdownDescription: "The filters to run before the action will fire and the action(s) to fire.",
@@ -935,6 +929,11 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					},
 				},
 			},
+			"legacy_trigger_conditions": schema.ListAttribute{
+				MarkdownDescription: "⚠️ The trigger condition types listed here are not natively supported by this provider and may be deprecated by Sentry in a future API version. Trigger condition types present on this alert that are not representable in `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`, `issue_resolution_change`). When omitted from config these will be removed on the next apply. Set explicitly to preserve them.",
+				Optional:            true,
+				CustomType:          supertypes.NewListTypeOf[string](ctx),
+			},
 		},
 	}
 }
@@ -1077,16 +1076,16 @@ func (r *AlertResource) ImportState(ctx context.Context, req resource.ImportStat
 }
 
 type AlertResourceModel struct {
-	Id                supertypes.StringValue                                                      `tfsdk:"id"`
-	Organization      supertypes.StringValue                                                      `tfsdk:"organization"`
-	Enabled           supertypes.BoolValue                                                        `tfsdk:"enabled"`
-	Name              supertypes.StringValue                                                      `tfsdk:"name"`
-	Environment       supertypes.StringValue                                                      `tfsdk:"environment"`
-	MonitorIds        supertypes.SetValueOf[string]                                               `tfsdk:"monitor_ids"`
-	FrequencyMinutes  supertypes.Int64Value                                                       `tfsdk:"frequency_minutes"`
+	Id                      supertypes.StringValue                                                      `tfsdk:"id"`
+	Organization            supertypes.StringValue                                                      `tfsdk:"organization"`
+	Enabled                 supertypes.BoolValue                                                        `tfsdk:"enabled"`
+	Name                    supertypes.StringValue                                                      `tfsdk:"name"`
+	Environment             supertypes.StringValue                                                      `tfsdk:"environment"`
+	MonitorIds              supertypes.SetValueOf[string]                                               `tfsdk:"monitor_ids"`
+	FrequencyMinutes        supertypes.Int64Value                                                       `tfsdk:"frequency_minutes"`
 	TriggerConditions       supertypes.ListNestedObjectValueOf[AlertResourceModelTriggerConditionsItem] `tfsdk:"trigger_conditions"`
-	LegacyTriggerConditions types.List                                                                   `tfsdk:"legacy_trigger_conditions"`
 	ActionFilters           supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItem]     `tfsdk:"action_filters"`
+	LegacyTriggerConditions supertypes.ListValueOf[string]                                              `tfsdk:"legacy_trigger_conditions"`
 }
 
 type AlertResourceModelTriggerConditionsItem struct {

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrydata"
 	"github.com/jianyuan/terraform-provider-sentry/internal/tfutils"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
@@ -133,6 +134,11 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						},
 					},
 				},
+			},
+			"legacy_trigger_conditions": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Trigger condition types present on this alert that are not configurable in the latest Sentry alerts UI similar to `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`). When omitted from config, any matching conditions returned by the API will be removed on the next apply.",
 			},
 			"action_filters": schema.ListNestedAttribute{
 				MarkdownDescription: "The filters to run before the action will fire and the action(s) to fire.",
@@ -1078,8 +1084,9 @@ type AlertResourceModel struct {
 	Environment       supertypes.StringValue                                                      `tfsdk:"environment"`
 	MonitorIds        supertypes.SetValueOf[string]                                               `tfsdk:"monitor_ids"`
 	FrequencyMinutes  supertypes.Int64Value                                                       `tfsdk:"frequency_minutes"`
-	TriggerConditions supertypes.ListNestedObjectValueOf[AlertResourceModelTriggerConditionsItem] `tfsdk:"trigger_conditions"`
-	ActionFilters     supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItem]     `tfsdk:"action_filters"`
+	TriggerConditions       supertypes.ListNestedObjectValueOf[AlertResourceModelTriggerConditionsItem] `tfsdk:"trigger_conditions"`
+	LegacyTriggerConditions types.List                                                                   `tfsdk:"legacy_trigger_conditions"`
+	ActionFilters           supertypes.ListNestedObjectValueOf[AlertResourceModelActionFiltersItem]     `tfsdk:"action_filters"`
 }
 
 type AlertResourceModelTriggerConditionsItem struct {

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -6,9 +6,7 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/go-utils/must"
 	"github.com/jianyuan/go-utils/ptr"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
@@ -610,19 +608,20 @@ func (r *AlertResource) getTriggerConditions(ctx context.Context, data AlertReso
 		outTriggerConditions = append(outTriggerConditions, outTriggerCondition)
 	}
 
-	if !data.LegacyTriggerConditions.IsNull() && !data.LegacyTriggerConditions.IsUnknown() {
-		for _, elem := range data.LegacyTriggerConditions.Elements() {
-			typeStr, ok := elem.(types.String)
-			if !ok || typeStr.IsNull() || typeStr.IsUnknown() {
-				continue
-			}
+	if data.LegacyTriggerConditions.IsKnown() {
+		inLegacyTriggerConditions := data.LegacyTriggerConditions.DiagsGet(ctx, diags)
+		if diags.HasError() {
+			return nil, diags
+		}
+
+		for _, inLegacyTriggerCondition := range inLegacyTriggerConditions {
 			var comp apiclient.OrganizationWorkflowTriggerCondition_Comparison
 			if err := comp.FromOrganizationWorkflowTriggerConditionComparison0(true); err != nil {
 				diags.AddError("Failed to build legacy trigger condition", err.Error())
 				return nil, diags
 			}
 			outTriggerConditions = append(outTriggerConditions, apiclient.OrganizationWorkflowTriggerCondition{
-				Type:            typeStr.ValueString(),
+				Type:            inLegacyTriggerCondition,
 				Comparison:      comp,
 				ConditionResult: true,
 			})
@@ -708,7 +707,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 	})
 
 	var triggerConditions []AlertResourceModelTriggerConditionsItem
-	var legacyElems []attr.Value
+	var legacyTriggerConditions []string
 	for _, triggerCondition := range triggers.Conditions {
 		outTriggerCondition := AlertResourceModelTriggerConditionsItem{
 			FirstSeenEvent:       supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemFirstSeenEvent](ctx),
@@ -730,14 +729,14 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			outTriggerCondition.RegressionEvent = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemRegressionEvent{})
 			triggerConditions = append(triggerConditions, outTriggerCondition)
 		default:
-			legacyElems = append(legacyElems, types.StringValue(triggerCondition.Type))
+			legacyTriggerConditions = append(legacyTriggerConditions, triggerCondition.Type)
 		}
 	}
 	m.TriggerConditions = supertypes.NewListNestedObjectValueOfValueSlice(ctx, triggerConditions)
-	if len(legacyElems) == 0 {
-		m.LegacyTriggerConditions = types.ListNull(types.StringType)
+	if len(legacyTriggerConditions) == 0 {
+		m.LegacyTriggerConditions.SetNull(ctx)
 	} else {
-		m.LegacyTriggerConditions = types.ListValueMust(types.StringType, legacyElems)
+		diags.Append(m.LegacyTriggerConditions.Set(ctx, legacyTriggerConditions)...)
 	}
 
 	actionFilters, err := data.ActionFilters.AsOrganizationWorkflowActionFilters0()

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -6,7 +6,9 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/go-utils/must"
 	"github.com/jianyuan/go-utils/ptr"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
@@ -608,6 +610,25 @@ func (r *AlertResource) getTriggerConditions(ctx context.Context, data AlertReso
 		outTriggerConditions = append(outTriggerConditions, outTriggerCondition)
 	}
 
+	if !data.LegacyTriggerConditions.IsNull() && !data.LegacyTriggerConditions.IsUnknown() {
+		for _, elem := range data.LegacyTriggerConditions.Elements() {
+			typeStr, ok := elem.(types.String)
+			if !ok || typeStr.IsNull() || typeStr.IsUnknown() {
+				continue
+			}
+			var comp apiclient.OrganizationWorkflowTriggerCondition_Comparison
+			if err := comp.FromOrganizationWorkflowTriggerConditionComparison0(true); err != nil {
+				diags.AddError("Failed to build legacy trigger condition", err.Error())
+				return nil, diags
+			}
+			outTriggerConditions = append(outTriggerConditions, apiclient.OrganizationWorkflowTriggerCondition{
+				Type:            typeStr.ValueString(),
+				Comparison:      comp,
+				ConditionResult: true,
+			})
+		}
+	}
+
 	return outTriggerConditions, diags
 }
 
@@ -687,6 +708,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 	})
 
 	var triggerConditions []AlertResourceModelTriggerConditionsItem
+	var legacyElems []attr.Value
 	for _, triggerCondition := range triggers.Conditions {
 		outTriggerCondition := AlertResourceModelTriggerConditionsItem{
 			FirstSeenEvent:       supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemFirstSeenEvent](ctx),
@@ -697,16 +719,26 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 		switch triggerCondition.Type {
 		case "first_seen_event":
 			outTriggerCondition.FirstSeenEvent = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemFirstSeenEvent{})
+			triggerConditions = append(triggerConditions, outTriggerCondition)
 		case "issue_resolved_trigger":
 			outTriggerCondition.IssueResolvedTrigger = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemIssueResolvedTrigger{})
+			triggerConditions = append(triggerConditions, outTriggerCondition)
 		case "reappeared_event":
 			outTriggerCondition.ReappearedEvent = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemReappearedEvent{})
+			triggerConditions = append(triggerConditions, outTriggerCondition)
 		case "regression_event":
 			outTriggerCondition.RegressionEvent = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemRegressionEvent{})
+			triggerConditions = append(triggerConditions, outTriggerCondition)
+		default:
+			legacyElems = append(legacyElems, types.StringValue(triggerCondition.Type))
 		}
-		triggerConditions = append(triggerConditions, outTriggerCondition)
 	}
 	m.TriggerConditions = supertypes.NewListNestedObjectValueOfValueSlice(ctx, triggerConditions)
+	if len(legacyElems) == 0 {
+		m.LegacyTriggerConditions = types.ListNull(types.StringType)
+	} else {
+		m.LegacyTriggerConditions = types.ListValueMust(types.StringType, legacyElems)
+	}
 
 	actionFilters, err := data.ActionFilters.AsOrganizationWorkflowActionFilters0()
 	if err != nil {

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -906,5 +906,13 @@ export default {
         },
       ],
     },
+    {
+      name: "legacy_trigger_conditions",
+      type: "list",
+      description:
+        "⚠️ The trigger condition types listed here are not natively supported by this provider and may be deprecated by Sentry in a future API version. Trigger condition types present on this alert that are not representable in `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`, `issue_resolution_change`). When omitted from config these will be removed on the next apply. Set explicitly to preserve them.",
+      computedOptionalRequired: "optional",
+      elementType: "string",
+    },
   ],
 } satisfies Resource;


### PR DESCRIPTION
## Summary

- Adds an optional `legacy_trigger_conditions` string list attribute to `sentry_alert` that surfaces trigger condition types returned by the API that are not configurable in the latest Sentry alerts UI (e.g. `new_high_priority_issue`, `existing_high_priority_issue`)
- When omitted from config, any such conditions on the alert will show as a diff on the next plan and be removed on apply — making drift visible rather than silently preserving it
- Adds example usage at `examples/resources/sentry_alert/resource-28-legacy_trigger_conditions.tf`

## Known limitation

`legacy_trigger_conditions` only supports conditions whose API representation is a boolean flag (`comparison: true`). Trigger conditions with structured parameters — specifically `event_frequency_count`, `event_unique_user_frequency_count`, and `percent_sessions_count` — can appear in the `triggers` block of an alert but cannot be represented as simple strings here. Attempting to import an alert with these conditions will result in only their type name being stored in state; the comparison parameters (value, interval) would be lost on the next apply. These must be managed outside of Terraform until structured support is added.

## Test plan

- [ ] `terraform plan` on an alert with `new_high_priority_issue` and `existing_high_priority_issue` shows no drift when both are declared in `legacy_trigger_conditions`
- [ ] Omitting `legacy_trigger_conditions` from config shows those conditions as planned removals
- [ ] `terraform apply` removes them cleanly with no subsequent drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)