### PR TITLE
fix(alert): skip empty TargetIdentifier when filling email action target_id

### DIFF
--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -916,7 +916,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			case apiclient.OrganizationWorkflowActionFilterActionEmail:
 				var outEmail AlertResourceModelActionFiltersItemActionsItemEmail
 				outEmail.TargetType = supertypes.NewStringValue(string(actionValue.Config.TargetType))
-				if actionValue.Config.TargetIdentifier != nil {
+				if actionValue.Config.TargetIdentifier != nil && *actionValue.Config.TargetIdentifier != "" {
 					outEmail.TargetId = supertypes.NewStringPointerValue(actionValue.Config.TargetIdentifier)
 				}
 				if actionValue.Data.FallthroughType != nil {


### PR DESCRIPTION
## Summary

- When reading an `issue_owners` email action from the API, `config.targetIdentifier` is returned as an empty string rather than `null`. The prior nil-only check stored an empty string in state for `target_id`, causing spurious drift on every plan.
- Added `&& *actionValue.Config.TargetIdentifier != ""` to treat empty string the same as nil.

## Test plan

- [ ] `terraform plan` on an alert with an `issue_owners` email action shows no changes after import/apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)