### PR TITLE
fix(alert): correct email action target_type values in example docs

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -120,7 +120,7 @@ resource "sentry_alert" "default" {
       actions = [
         {
           email = {
-            target_type      = "IssueOwners"
+            target_type      = "issue_owners"
             fallthrough_type = "AllMembers"
           }
         }
@@ -129,7 +129,7 @@ resource "sentry_alert" "default" {
   ]
 }
 
-# Send a notification to a team. If no issue owners, then send to all members.
+# Send a notification to a team.
 data "sentry_team" "team" { /* ... */ }
 
 resource "sentry_alert" "default" {
@@ -141,9 +141,8 @@ resource "sentry_alert" "default" {
       actions = [
         {
           email = {
-            target_type       = "Team"
-            target_identifier = data.sentry_team.team.internal_id
-            fallthrough_type  = "AllMembers"
+            target_type = "team"
+            target_id   = data.sentry_team.team.internal_id
           }
         }
       ]
@@ -151,7 +150,7 @@ resource "sentry_alert" "default" {
   ]
 }
 
-# Send a notification to a user. If no issue owners, then send to all members.
+# Send a notification to a user.
 data "sentry_organization_member" "member" { /* ... */ }
 
 resource "sentry_alert" "default" {
@@ -163,9 +162,8 @@ resource "sentry_alert" "default" {
       actions = [
         {
           email = {
-            target_type       = "Member"
-            target_identifier = data.sentry_organization_member.member.internal_id
-            fallthrough_type  = "AllMembers"
+            target_type = "user"
+            target_id   = data.sentry_organization_member.member.internal_id
           }
         }
       ]

--- a/examples/resources/sentry_alert/resource-02-email.tf
+++ b/examples/resources/sentry_alert/resource-02-email.tf
@@ -8,7 +8,7 @@ resource "sentry_alert" "default" {
       actions = [
         {
           email = {
-            target_type      = "IssueOwners"
+            target_type      = "issue_owners"
             fallthrough_type = "AllMembers"
           }
         }
@@ -17,7 +17,7 @@ resource "sentry_alert" "default" {
   ]
 }
 
-# Send a notification to a team. If no issue owners, then send to all members.
+# Send a notification to a team.
 data "sentry_team" "team" { /* ... */ }
 
 resource "sentry_alert" "default" {
@@ -29,9 +29,8 @@ resource "sentry_alert" "default" {
       actions = [
         {
           email = {
-            target_type       = "Team"
-            target_identifier = data.sentry_team.team.internal_id
-            fallthrough_type  = "AllMembers"
+            target_type = "team"
+            target_id   = data.sentry_team.team.internal_id
           }
         }
       ]
@@ -39,7 +38,7 @@ resource "sentry_alert" "default" {
   ]
 }
 
-# Send a notification to a user. If no issue owners, then send to all members.
+# Send a notification to a user.
 data "sentry_organization_member" "member" { /* ... */ }
 
 resource "sentry_alert" "default" {
@@ -51,9 +50,8 @@ resource "sentry_alert" "default" {
       actions = [
         {
           email = {
-            target_type       = "Member"
-            target_identifier = data.sentry_organization_member.member.internal_id
-            fallthrough_type  = "AllMembers"
+            target_type = "user"
+            target_id   = data.sentry_organization_member.member.internal_id
           }
         }
       ]


### PR DESCRIPTION
## Summary

- Corrects `target_type` values in examples and generated docs from PascalCase (`IssueOwners`, `Team`, `Member`) to the snake_case values the API and schema validators expect (`issue_owners`, `team`, `user`)
- Renames `target_identifier` to `target_id` to match the actual schema attribute name
- Removes incorrect `fallthrough_type` from team and user email action examples (only valid for `issue_owners`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)