### PR TITLE
fix(alert): add include field to issue_category condition

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1153,6 +1153,10 @@ Required:
 
 - `value` (Number) The issue category to filter to.
 
+Optional:
+
+- `include` (Boolean) If `true`, the condition matches when the issue category is equal to `value`. If `false`, the condition matches when it is not equal. Defaults to `true`.
+
 
 <a id="nestedatt--action_filters--conditions--issue_occurrences"></a>
 ### Nested Schema for `action_filters.conditions.issue_occurrences`

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -3175,6 +3175,8 @@ components:
             value:
               type: integer
               format: int64
+            include:
+              type: boolean
         conditionResult:
           type: boolean
     OrganizationWorkflow_ActionFilter_Condition_IssueOccurrences:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -1973,7 +1973,8 @@ type OrganizationWorkflowActionFilterConditionEventUniqueUserFrequencyCountFilte
 // OrganizationWorkflowActionFilterConditionIssueCategory defines model for OrganizationWorkflow_ActionFilter_Condition_IssueCategory.
 type OrganizationWorkflowActionFilterConditionIssueCategory struct {
 	Comparison struct {
-		Value int64 `json:"value"`
+		Include *bool `json:"include,omitempty"`
+		Value   int64 `json:"value"`
 	} `json:"comparison"`
 	ConditionResult bool                                                       `json:"conditionResult"`
 	Type            OrganizationWorkflowActionFilterConditionIssueCategoryType `json:"type"`

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -232,6 +232,12 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												Required:            true,
 												CustomType:          supertypes.Int64Type{},
 											},
+											"include": schema.BoolAttribute{
+												MarkdownDescription: "If `true`, the condition matches when the issue category is equal to `value`. If `false`, the condition matches when it is not equal. Defaults to `true`.",
+												Optional:            true,
+												Computed:            true,
+												CustomType:          supertypes.BoolType{},
+											},
 										},
 									},
 									"issue_occurrences": schema.SingleNestedAttribute{
@@ -1144,7 +1150,8 @@ type AlertResourceModelActionFiltersItemConditionsItemAssignedTo struct {
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemIssueCategory struct {
-	Value supertypes.Int64Value `tfsdk:"value"`
+	Value   supertypes.Int64Value `tfsdk:"value"`
+	Include supertypes.BoolValue  `tfsdk:"include"`
 }
 
 type AlertResourceModelActionFiltersItemConditionsItemIssueOccurrences struct {

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -85,6 +85,7 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 
 				var outIssueCategory apiclient.OrganizationWorkflowActionFilterConditionIssueCategory
 				outIssueCategory.Comparison.Value = inIssueCategory.Value.Get()
+				outIssueCategory.Comparison.Include = ptr.Ptr(inIssueCategory.Include.Get())
 				outIssueCategory.ConditionResult = true
 
 				if err := outCondition.FromOrganizationWorkflowActionFilterConditionIssueCategory(outIssueCategory); err != nil {
@@ -819,6 +820,11 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			case apiclient.OrganizationWorkflowActionFilterConditionIssueCategory:
 				var issueCategory AlertResourceModelActionFiltersItemConditionsItemIssueCategory
 				issueCategory.Value = supertypes.NewInt64Value(conditionValue.Comparison.Value)
+				if conditionValue.Comparison.Include != nil {
+					issueCategory.Include = supertypes.NewBoolValue(*conditionValue.Comparison.Include)
+				} else {
+					issueCategory.Include = supertypes.NewBoolValue(true)
+				}
 
 				outCondition.IssueCategory = supertypes.NewSingleNestedObjectValueOf(ctx, &issueCategory)
 

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/jianyuan/go-utils/must"
-	"github.com/jianyuan/go-utils/ptr"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/tfutils"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
@@ -85,7 +84,7 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 
 				var outIssueCategory apiclient.OrganizationWorkflowActionFilterConditionIssueCategory
 				outIssueCategory.Comparison.Value = inIssueCategory.Value.Get()
-				outIssueCategory.Comparison.Include = ptr.Ptr(inIssueCategory.Include.Get())
+				outIssueCategory.Comparison.Include = new(inIssueCategory.Include.Get())
 				outIssueCategory.ConditionResult = true
 
 				if err := outCondition.FromOrganizationWorkflowActionFilterConditionIssueCategory(outIssueCategory); err != nil {
@@ -328,7 +327,7 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				outEmail.Config.TargetType = apiclient.OrganizationWorkflowActionFilterActionEmailConfigTargetType(inEmail.TargetType.Get())
 				outEmail.Config.TargetIdentifier = inEmail.TargetId.GetPtr()
 				if inEmail.FallthroughType.IsKnown() {
-					outEmail.Data.FallthroughType = ptr.Ptr(apiclient.OrganizationWorkflowActionFilterActionEmailDataFallthroughType(inEmail.FallthroughType.Get()))
+					outEmail.Data.FallthroughType = new(apiclient.OrganizationWorkflowActionFilterActionEmailDataFallthroughType(inEmail.FallthroughType.Get()))
 				}
 
 				if err := outAction.FromOrganizationWorkflowActionFilterActionEmail(outEmail); err != nil {
@@ -357,10 +356,10 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				outSlack.Config.TargetIdentifier = inSlack.ChannelId.Get()
 				outSlack.Config.TargetDisplay = inSlack.ChannelName.Get()
 				if inSlack.Tags.IsKnown() {
-					outSlack.Data.Tags = ptr.Ptr(inSlack.Tags.Get())
+					outSlack.Data.Tags = new(inSlack.Tags.Get())
 				}
 				if inSlack.Notes.IsKnown() {
-					outSlack.Data.Notes = ptr.Ptr(inSlack.Notes.Get())
+					outSlack.Data.Notes = new(inSlack.Notes.Get())
 				}
 
 				if err := outAction.FromOrganizationWorkflowActionFilterActionSlack(outSlack); err != nil {
@@ -397,7 +396,7 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				outDiscord.Config.TargetType = "specific"
 				outDiscord.Config.TargetIdentifier = inDiscord.ChannelId.Get()
 				if inDiscord.Tags.IsKnown() {
-					outDiscord.Data.Tags = ptr.Ptr(inDiscord.Tags.Get())
+					outDiscord.Data.Tags = new(inDiscord.Tags.Get())
 				}
 
 				if err := outAction.FromOrganizationWorkflowActionFilterActionDiscord(outDiscord); err != nil {

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -199,6 +199,13 @@ export default {
                   description: "The issue category to filter to.",
                   computedOptionalRequired: "required",
                 },
+                {
+                  name: "include",
+                  type: "bool",
+                  description:
+                    "If `true`, the condition matches when the issue category is equal to `value`. If `false`, the condition matches when it is not equal. Defaults to `true`.",
+                  computedOptionalRequired: "computed_optional",
+                },
               ],
             },
             {


### PR DESCRIPTION
## Summary

Adds an optional `include` boolean field to the `issue_category` condition in `sentry_alert` action filters, matching the field already present on `issue_type`.

- `include: true` (default) — condition matches when the issue category equals `value`
- `include: false` — condition matches when the issue category does not equal `value`

When the API returns `null` for `include`, the provider defaults to `true` to match Sentry's backend behaviour. The field is `Optional+Computed` so existing configs need no changes.

## Test plan

- [ ] `terraform plan` on an alert with an `issue_category` condition shows no drift after import/apply
- [ ] Setting `include = false` produces a plan that updates the condition and round-trips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)