### PR TITLE
fix(alert): make environment Optional to support all-environments alerts

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -859,7 +859,6 @@ resource "sentry_alert" "default" {
 ### Required
 
 - `action_filters` (Attributes List) The filters to run before the action will fire and the action(s) to fire. (see [below for nested schema](#nestedatt--action_filters))
-- `environment` (String) Name of the environment to create alerts in.
 - `frequency_minutes` (Number) How often the alert should fire in minutes.
 - `monitor_ids` (Set of String) The IDs of the monitors to create alerts for.
 - `name` (String) The name of this alert.
@@ -869,6 +868,7 @@ resource "sentry_alert" "default" {
 ### Optional
 
 - `enabled` (Boolean) Whether the alert is enabled. Defaults to `true`.
+- `environment` (String) The environment to filter alerts to. Omit or set to null to apply to all environments.
 - `legacy_trigger_conditions` (List of String) ⚠️ The trigger condition types listed here are not natively supported by this provider and may be deprecated by Sentry in a future API version. Trigger condition types present on this alert that are not representable in `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`, `issue_resolution_change`). When omitted from config these will be removed on the next apply. Set explicitly to preserve them.
 
 ### Read-Only
@@ -927,7 +927,7 @@ Required:
 
 Optional:
 
-- `fallthrough_type` (String) The type of fallthrough to apply when choosing to notify issue owners. Only required if the target type is `issue_owners`. Valid values are: `AllMembers`, `ActiveMembers`, and `NoOne`.
+- `fallthrough_type` (String) The type of fallthrough to apply when choosing to notify issue owners. Required when `target_type` is `issue_owners`. Valid values are: `AllMembers`, `ActiveMembers`, and `NoOne`.
 - `target_id` (String) The internal ID of the user or team. Only required if the target type is `team` or `user`.
 
 

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -868,7 +868,7 @@ resource "sentry_alert" "default" {
 ### Optional
 
 - `enabled` (Boolean) Whether the alert is enabled. Defaults to `true`.
-- `environment` (String) The environment to filter alerts to. Omit or set to null to apply to all environments.
+- `environment` (String) The environment to filter alerts to. Omit or set to `null` to apply to all environments.
 - `legacy_trigger_conditions` (List of String) ⚠️ The trigger condition types listed here are not natively supported by this provider and may be deprecated by Sentry in a future API version. Trigger condition types present on this alert that are not representable in `trigger_conditions` (e.g. `new_high_priority_issue`, `existing_high_priority_issue`, `issue_resolution_change`). When omitted from config these will be removed on the next apply. Set explicitly to preserve them.
 
 ### Read-Only
@@ -927,7 +927,7 @@ Required:
 
 Optional:
 
-- `fallthrough_type` (String) The type of fallthrough to apply when choosing to notify issue owners. Required when `target_type` is `issue_owners`. Valid values are: `AllMembers`, `ActiveMembers`, and `NoOne`.
+- `fallthrough_type` (String) The type of fallthrough to apply when choosing to notify issue owners. Only required if the target type is `issue_owners`. Valid values are: `AllMembers`, `ActiveMembers`, and `NoOne`.
 - `target_id` (String) The internal ID of the user or team. Only required if the target type is `team` or `user`.
 
 

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -2923,7 +2923,6 @@ components:
       required:
         - name
         - enabled
-        - environment
         - config
         - detectorIds
         - triggers
@@ -2935,6 +2934,7 @@ components:
           type: boolean
         environment:
           type: string
+          nullable: true
         config:
           $ref: "#/components/schemas/OrganizationWorkflow_Config"
         detectorIds:
@@ -2962,7 +2962,6 @@ components:
         - id
         - name
         - enabled
-        - environment
         - config
         - detectorIds
         - triggers
@@ -2976,6 +2975,7 @@ components:
           type: boolean
         environment:
           type: string
+          nullable: true
         config:
           $ref: "#/components/schemas/OrganizationWorkflow_Config"
         detectorIds:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -1565,7 +1565,7 @@ type OrganizationWorkflow struct {
 	Config        OrganizationWorkflowConfig         `json:"config"`
 	DetectorIds   []string                           `json:"detectorIds"`
 	Enabled       bool                               `json:"enabled"`
-	Environment   string                             `json:"environment"`
+	Environment   nullable.Nullable[string]          `json:"environment,omitempty"`
 	Id            string                             `json:"id"`
 	Name          string                             `json:"name"`
 	Triggers      OrganizationWorkflow_Triggers      `json:"triggers"`
@@ -1596,7 +1596,7 @@ type OrganizationWorkflowRequest struct {
 	Config        OrganizationWorkflowConfig         `json:"config"`
 	DetectorIds   []string                           `json:"detectorIds"`
 	Enabled       bool                               `json:"enabled"`
-	Environment   string                             `json:"environment"`
+	Environment   nullable.Nullable[string]          `json:"environment,omitempty"`
 	Name          string                             `json:"name"`
 	Triggers      OrganizationWorkflowTrigger        `json:"triggers"`
 }
@@ -2942,7 +2942,7 @@ type UpdateOrganizationWorkflowRequest struct {
 	Config        OrganizationWorkflowConfig         `json:"config"`
 	DetectorIds   []string                           `json:"detectorIds"`
 	Enabled       bool                               `json:"enabled"`
-	Environment   string                             `json:"environment"`
+	Environment   nullable.Nullable[string]          `json:"environment,omitempty"`
 	Id            string                             `json:"id"`
 	Name          string                             `json:"name"`
 	Triggers      OrganizationWorkflowTrigger        `json:"triggers"`

--- a/internal/provider/data_source_alert_gen.go
+++ b/internal/provider/data_source_alert_gen.go
@@ -124,7 +124,11 @@ func (m *AlertDataSourceModel) Fill(ctx context.Context, data apiclient.Organiza
 	m.Id = supertypes.NewStringValue(data.Id)
 	m.Enabled = supertypes.NewBoolValue(data.Enabled)
 	m.Name = supertypes.NewStringValue(data.Name)
-	m.Environment = supertypes.NewStringValue(data.Environment)
+	if v, err := data.Environment.Get(); err == nil {
+		m.Environment = supertypes.NewStringValueOrNull(v)
+	} else {
+		m.Environment = supertypes.NewStringNull()
+	}
 	m.MonitorIds = supertypes.NewSetValueOfSlice(ctx, data.DetectorIds)
 	m.FrequencyMinutes = supertypes.NewInt64Value(data.Config.Frequency)
 

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -72,8 +72,8 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				CustomType:          supertypes.StringType{},
 			},
 			"environment": schema.StringAttribute{
-				MarkdownDescription: "Name of the environment to create alerts in.",
-				Required:            true,
+				MarkdownDescription: "The environment to filter alerts to. Omit or set to null to apply to all environments.",
+				Optional:            true,
 				CustomType:          supertypes.StringType{},
 			},
 			"monitor_ids": schema.SetAttribute{
@@ -616,7 +616,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 											},
 											"fallthrough_type": tfutils.WithEnumStringAttribute(
 												schema.StringAttribute{
-													MarkdownDescription: "The type of fallthrough to apply when choosing to notify issue owners. Only required if the target type is `issue_owners`.",
+													MarkdownDescription: "The type of fallthrough to apply when choosing to notify issue owners. Required when `target_type` is `issue_owners`.",
 													Optional:            true,
 													CustomType:          supertypes.StringType{},
 													Validators: []validator.String{

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -72,7 +72,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 				CustomType:          supertypes.StringType{},
 			},
 			"environment": schema.StringAttribute{
-				MarkdownDescription: "The environment to filter alerts to. Omit or set to null to apply to all environments.",
+				MarkdownDescription: "The environment to filter alerts to. Omit or set to `null` to apply to all environments.",
 				Optional:            true,
 				CustomType:          supertypes.StringType{},
 			},
@@ -616,7 +616,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 											},
 											"fallthrough_type": tfutils.WithEnumStringAttribute(
 												schema.StringAttribute{
-													MarkdownDescription: "The type of fallthrough to apply when choosing to notify issue owners. Required when `target_type` is `issue_owners`.",
+													MarkdownDescription: "The type of fallthrough to apply when choosing to notify issue owners. Only required if the target type is `issue_owners`.",
 													Optional:            true,
 													CustomType:          supertypes.StringType{},
 													Validators: []validator.String{

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -10,9 +10,17 @@ import (
 	"github.com/jianyuan/go-utils/must"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/tfutils"
+	"github.com/oapi-codegen/nullable"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
 	"github.com/samber/lo"
 )
+
+func nullableFromPtr[T any](v *T) nullable.Nullable[T] {
+	if v == nil {
+		return nullable.NewNullNullable[T]()
+	}
+	return nullable.NewNullableWithValue(*v)
+}
 
 func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResourceModel) ([]apiclient.OrganizationWorkflowActionFilter, diag.Diagnostics) {
 	var diags diag.Diagnostics
@@ -642,7 +650,7 @@ func (r *AlertResource) getCreateJSONRequestBody(ctx context.Context, data Alert
 	req := apiclient.CreateOrganizationWorkflowJSONRequestBody{
 		Name:        data.Name.Get(),
 		Enabled:     data.Enabled.Get(),
-		Environment: data.Environment.Get(),
+		Environment: nullableFromPtr(data.Environment.GetPtr()),
 		Config: apiclient.OrganizationWorkflowConfig{
 			Frequency: data.FrequencyMinutes.Get(),
 		},
@@ -669,7 +677,7 @@ func (r *AlertResource) getUpdateJSONRequestBody(ctx context.Context, data Alert
 		Id:          data.Id.Get(),
 		Name:        data.Name.Get(),
 		Enabled:     data.Enabled.Get(),
-		Environment: data.Environment.Get(),
+		Environment: nullableFromPtr(data.Environment.GetPtr()),
 		Config: apiclient.OrganizationWorkflowConfig{
 			Frequency: data.FrequencyMinutes.Get(),
 		},
@@ -688,7 +696,11 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 	m.Id = supertypes.NewStringValue(data.Id)
 	m.Name = supertypes.NewStringValue(data.Name)
 	m.Enabled = supertypes.NewBoolValue(data.Enabled)
-	m.Environment = supertypes.NewStringValue(data.Environment)
+	if v, err := data.Environment.Get(); err == nil {
+		m.Environment = supertypes.NewStringValueOrNull(v)
+	} else {
+		m.Environment = supertypes.NewStringNull()
+	}
 	m.FrequencyMinutes = supertypes.NewInt64Value(data.Config.Frequency)
 	m.MonitorIds = supertypes.NewSetValueOfSlice(ctx, data.DetectorIds)
 

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -10,17 +10,9 @@ import (
 	"github.com/jianyuan/go-utils/must"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/tfutils"
-	"github.com/oapi-codegen/nullable"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
 	"github.com/samber/lo"
 )
-
-func nullableFromPtr[T any](v *T) nullable.Nullable[T] {
-	if v == nil {
-		return nullable.NewNullNullable[T]()
-	}
-	return nullable.NewNullableWithValue(*v)
-}
 
 func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResourceModel) ([]apiclient.OrganizationWorkflowActionFilter, diag.Diagnostics) {
 	var diags diag.Diagnostics

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/oapi-codegen/nullable"
 )
 
 func ResourceIdAttribute() schema.Attribute {
@@ -48,4 +49,11 @@ func DataSourceProjectAttribute() schema.Attribute {
 		MarkdownDescription: "The project the resource belongs to.",
 		Required:            true,
 	}
+}
+
+func nullableFromPtr[T any](v *T) nullable.Nullable[T] {
+	if v == nil {
+		return nullable.NewNullNullable[T]()
+	}
+	return nullable.NewNullableWithValue(*v)
 }

--- a/internal/providergen/data_sources/alert.ts
+++ b/internal/providergen/data_sources/alert.ts
@@ -49,6 +49,7 @@ export default {
       type: "string",
       description: "Name of the environment for this alert.",
       computedOptionalRequired: "computed",
+      nullable: true,
     },
     {
       name: "monitor_ids",

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -57,8 +57,9 @@ export default {
     {
       name: "environment",
       type: "string",
-      description: "Name of the environment to create alerts in.",
-      computedOptionalRequired: "required",
+      description:
+        "The environment to filter alerts to. Omit or set to `null` to apply to all environments.",
+      computedOptionalRequired: "optional",
     },
     {
       name: "monitor_ids",


### PR DESCRIPTION
## Summary

`environment` was `Required` on `sentry_alert`, preventing users from creating alerts that apply to all environments (no environment filter).

- Changed `environment` to `Optional` (no `Computed`) so omitting it leaves state null and produces no plan noise
- Made the `environment` field nullable in `api.yaml` so round-tripping `null`/empty from the API works correctly
- Added a `nullableFromPtr` helper used in create/update request bodies
- Updated `Fill()` in both the resource and data source to handle a nullable environment

## Test plan

- [ ] Creating a `sentry_alert` without `environment` succeeds and shows no drift on subsequent plan
- [ ] Creating a `sentry_alert` with `environment = "production"` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)