### PR TITLE
fix(organization_member): preserve null role in teamRoles round-trip

### DIFF
--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -1356,11 +1356,13 @@ components:
       type: object
       required:
         - teamSlug
+        - role
       properties:
         teamSlug:
           type: string
         role:
           type: string
+          nullable: true
     OrganizationMemberWithRoles:
       type: object
       required:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -2956,8 +2956,8 @@ type Team struct {
 
 // TeamRole defines model for TeamRole.
 type TeamRole struct {
-	Role     *string `json:"role,omitempty"`
-	TeamSlug string  `json:"teamSlug"`
+	Role     nullable.Nullable[string] `json:"role"`
+	TeamSlug string                    `json:"teamSlug"`
 }
 
 // TeamRoleListItem defines model for TeamRoleListItem.

--- a/internal/apiclient/teamrole_test.go
+++ b/internal/apiclient/teamrole_test.go
@@ -1,0 +1,47 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/oapi-codegen/nullable"
+)
+
+func TestTeamRoleMarshalRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{"explicit null role", `{"teamSlug":"test","role":null}`, `{"role":null,"teamSlug":"test"}`},
+		{"valued role", `{"teamSlug":"test","role":"admin"}`, `{"role":"admin","teamSlug":"test"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var tr TeamRole
+			if err := json.Unmarshal([]byte(tc.in), &tr); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			b, err := json.Marshal(tr)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			if string(b) != tc.out {
+				t.Errorf("round-trip mismatch:\n  in:  %s\n  got: %s\n  want:%s", tc.in, b, tc.out)
+			}
+		})
+	}
+}
+
+func TestTeamRoleMarshalConstructed(t *testing.T) {
+	// Null roles should marshal as an explicit null
+	tr := TeamRole{TeamSlug: "test", Role: nullable.NewNullNullable[string]()}
+	b, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	want := `{"role":null,"teamSlug":"test"}`
+	if string(b) != want {
+		t.Errorf("got %s, want %s", b, want)
+	}
+}

--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -142,9 +142,9 @@ func (r *TeamMemberResource) getEffectiveTeamRole(ctx context.Context, organizat
 
 	if teamRoleId, ok := lo.Find(member.TeamRoles, func(teamRole apiclient.TeamRole) bool {
 		return teamRole.TeamSlug == teamSlug
-	}); ok && teamRoleId.Role != nil {
+	}); ok && teamRoleId.Role.IsSpecified() && !teamRoleId.Role.IsNull() {
 		if teamRole, ok := lo.Find(org.TeamRoleList, func(teamRole apiclient.TeamRoleListItem) bool {
-			return teamRole.Id == *teamRoleId.Role
+			return teamRole.Id == teamRoleId.Role.MustGet()
 		}); ok {
 			return &teamRole.Id, nil
 		}


### PR DESCRIPTION
### [Sentry Documentation](https://docs.sentry.io/api/organizations/update-an-organization-members-roles/)

---

The TeamRole schema in `api.yaml` declared role as a non-required string, which oapi-codegen rendered as
```
Role *string `json:"role,omitempty"
```

On a `GET` response containing `role: null`, the field unmarshalled to a nil pointer; on the subsequent `PUT`, `omitempty` stripped the key entirely. Sentry's API returns `500 Internal Error` when a `teamRoles` entry omits the `role` key (instead of validating and returning 4xx).

Mark role as both required & nullable so the regenerated client uses `nullable.Nullable[string]`, which always emits the key — `null` stays `null` across the round-trip and the `PUT` body now includes `role: null`.

Reproducer (against any member with a team membership where role is null, which is the default for non-team-admins):
```bash
PUT /api/0/organizations/{org}/members/{id}/
Body: {"orgRole":"owner","teamRoles":[{"teamSlug":"x"}]}
```
yields a `500` with
```json
{"detail":"Internal Error","errorId":"..."}
```

After this fix it yields a `200` with:
```json
{"orgRole":"owner","teamRoles":[{"teamSlug":"x","role":null}]}
```

fixes https://github.com/jianyuan/terraform-provider-sentry/issues/841