### PR TITLE
fix(issue-alert): strip label from legacy action settings to fix apply drift

### DIFF
--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -1630,7 +1630,9 @@ func (m *IssueAlertModel) Fill(ctx context.Context, alert apiclient.ProjectRule)
 // stripLegacyActionDisplayFields removes API-injected display-only keys from the legacy
 // action JSON before storing in state. The Sentry GET endpoint unconditionally adds
 // "formFields" (live webhook schema) and "name" (generated label) to every action dict.
-// These fields are never stored server-side and cannot be stabilized in config.
+// These fields are never stored server-side and cannot be stabilized in config. The
+// nested "settings" array on sentry-app actions has the same problem with per-entry
+// "label" values, which the API returns on PUT but omits on GET.
 func stripLegacyActionDisplayFields(actionJSON []byte) ([]byte, error) {
 	dec := json.NewDecoder(bytes.NewReader(actionJSON))
 	dec.UseNumber()
@@ -1643,6 +1645,14 @@ func stripLegacyActionDisplayFields(actionJSON []byte) ([]byte, error) {
 	delete(action, "formFields")
 	delete(action, "name")
 	delete(action, "hasSchemaFormConfig")
+
+	if settings, ok := action["settings"].([]interface{}); ok {
+		for _, s := range settings {
+			if entry, ok := s.(map[string]interface{}); ok {
+				delete(entry, "label")
+			}
+		}
+	}
 
 	return json.Marshal(action)
 }

--- a/internal/provider/model_issue_alert_test.go
+++ b/internal/provider/model_issue_alert_test.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStripLegacyActionDisplayFields(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		input    string
+		expected map[string]interface{}
+	}{
+		"removes top-level display fields": {
+			input:    `{"id":"x","name":"display","formFields":{"a":1},"hasSchemaFormConfig":true}`,
+			expected: map[string]interface{}{"id": "x"},
+		},
+		"strips label from settings entries": {
+			input: `{"id":"sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction","sentryAppInstallationUuid":"u","settings":[{"label":"[Team] foo","name":"target","value":"Group:1"},{"label":"P3","name":"urgency","value":"abc"}]}`,
+			expected: map[string]interface{}{
+				"id":                        "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
+				"sentryAppInstallationUuid": "u",
+				"settings": []interface{}{
+					map[string]interface{}{"name": "target", "value": "Group:1"},
+					map[string]interface{}{"name": "urgency", "value": "abc"},
+				},
+			},
+		},
+		"leaves settings entries without label untouched": {
+			input: `{"id":"x","settings":[{"name":"n","value":"v"}]}`,
+			expected: map[string]interface{}{
+				"id": "x",
+				"settings": []interface{}{
+					map[string]interface{}{"name": "n", "value": "v"},
+				},
+			},
+		},
+		"no settings key is a no-op": {
+			input:    `{"id":"x"}`,
+			expected: map[string]interface{}{"id": "x"},
+		},
+	}
+	for name, tc := range testCases {
+		name, tc := name, tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := stripLegacyActionDisplayFields([]byte(tc.input))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var gotMap map[string]interface{}
+			if err := json.Unmarshal(got, &gotMap); err != nil {
+				t.Fatalf("output is not valid JSON: %v", err)
+			}
+
+			if diff := cmp.Diff(gotMap, tc.expected); diff != "" {
+				t.Errorf("unexpected stripped JSON (-got, +expected): %s", diff)
+			}
+		})
+	}
+}

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -341,7 +341,14 @@ func (r *IssueAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 				MarkdownDescription: "**Deprecated** in favor of `actions_v2`. A list of actions that take place when all required conditions and filters for the rule are met. In JSON string format.",
 				DeprecationMessage:  "Use `actions_v2` instead.",
 				Optional:            true,
-				CustomType:          sentrytypes.LossyJsonType{},
+				// "label" is API-injected display text on sentry-app action settings
+				// entries — returned on PUT but omitted on GET. Ignoring it lets existing
+				// configs keep label keys while state stores the canonical (label-free)
+				// form. The ignore is recursive: any "label" key in the actions JSON is
+				// dropped from comparison.
+				CustomType: sentrytypes.LossyJsonType{
+					IgnoreKeys: []string{"label"},
+				},
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("actions_v2")),
 				},

--- a/internal/sentrytypes/lossy_json_value.go
+++ b/internal/sentrytypes/lossy_json_value.go
@@ -147,7 +147,23 @@ func deepLossyEqual(v1, v2 interface{}, ignoreKeys []string) bool {
 			return false
 		}
 
-		if len(v1) > len(v2) {
+		// Count keys on each side excluding ignored keys. Ignored keys are allowed to
+		// appear on either side without affecting equality, so they must not contribute
+		// to the lossy length gate below.
+		v1Count := 0
+		for k := range v1 {
+			if !slices.Contains(ignoreKeys, k) {
+				v1Count++
+			}
+		}
+		v2Count := 0
+		for k := range v2 {
+			if !slices.Contains(ignoreKeys, k) {
+				v2Count++
+			}
+		}
+
+		if v1Count > v2Count {
 			return false
 		}
 

--- a/internal/sentrytypes/lossy_json_value_test.go
+++ b/internal/sentrytypes/lossy_json_value_test.go
@@ -150,6 +150,37 @@ func TestLossyJsonStringSemanticEquals(t *testing.T) {
 			givenJson:     NewLossyJsonValue(`[{"hello": "world"}, {"nums":[1, 2, 3]}, {"nested": {"test-bool": true, "new-field": null}}]`),
 			expectedMatch: false,
 		},
+		"semantically equal - ignored key present only in given value": {
+			currentJson:   LossyJson{StringValue: basetypes.NewStringValue(`{"name": "n", "value": "v"}`), IgnoreKeys: []string{"label"}},
+			givenJson:     LossyJson{StringValue: basetypes.NewStringValue(`{"label": "L", "name": "n", "value": "v"}`), IgnoreKeys: []string{"label"}},
+			expectedMatch: true,
+		},
+		"semantically equal - ignored key present only in current value": {
+			currentJson:   LossyJson{StringValue: basetypes.NewStringValue(`{"label": "L", "name": "n", "value": "v"}`), IgnoreKeys: []string{"label"}},
+			givenJson:     LossyJson{StringValue: basetypes.NewStringValue(`{"name": "n", "value": "v"}`), IgnoreKeys: []string{"label"}},
+			expectedMatch: true,
+		},
+		"semantically equal - ignored key present on both sides with different values": {
+			currentJson:   LossyJson{StringValue: basetypes.NewStringValue(`{"label": "old", "name": "n", "value": "v"}`), IgnoreKeys: []string{"label"}},
+			givenJson:     LossyJson{StringValue: basetypes.NewStringValue(`{"label": "new", "name": "n", "value": "v"}`), IgnoreKeys: []string{"label"}},
+			expectedMatch: true,
+		},
+		"not equal - non-ignored key differs even when ignored key matches": {
+			currentJson:   LossyJson{StringValue: basetypes.NewStringValue(`{"label": "L", "name": "n", "value": "old"}`), IgnoreKeys: []string{"label"}},
+			givenJson:     LossyJson{StringValue: basetypes.NewStringValue(`{"label": "L", "name": "n", "value": "new"}`), IgnoreKeys: []string{"label"}},
+			expectedMatch: false,
+		},
+		"semantically equal - ignored key nested inside array of objects": {
+			currentJson: LossyJson{
+				StringValue: basetypes.NewStringValue(`{"id":"x","settings":[{"name":"n","value":"v"}]}`),
+				IgnoreKeys:  []string{"label"},
+			},
+			givenJson: LossyJson{
+				StringValue: basetypes.NewStringValue(`{"id":"x","settings":[{"label":"L","name":"n","value":"v"}]}`),
+				IgnoreKeys:  []string{"label"},
+			},
+			expectedMatch: true,
+		},
 	}
 	for name, testCase := range testCases {
 		name, testCase := name, testCase


### PR DESCRIPTION
Legacy `actions` JSON containing a `notify_event_sentry_app` action with a `settings` array fails apply with `Provider produced inconsistent result after apply` — the Sentry API echoes `label` on PUT responses but omits it on GET, so state and the planned value disagree. Same shape as #823, one level deeper.

Fix:
- `stripLegacyActionDisplayFields` also drops `label` from each `settings` entry.
- `actions` schema declares `LossyJsonType{IgnoreKeys: []string{"label"}}` (mirrors `conditions` ignoring `name`).
- `deepLossyEqual`'s length gate now excludes ignored keys on both sides so `IgnoreKeys` is symmetric.

**Heads-up:** the last change also affects `conditions` (`IgnoreKeys: ["name"]`). Previously, including `name` in a `conditions` config triggered drift; now it's silently accepted. The API always echoes `name` into state, so configs rarely include it — but the behavior change is real.

No config changes required for existing users.