### PR TITLE
fix(metric_monitor): support fractional comparison thresholds

### DIFF
--- a/internal/provider/data_source_metric_monitor_gen.go
+++ b/internal/provider/data_source_metric_monitor_gen.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
 )
@@ -156,10 +157,9 @@ func (d *MetricMonitorDataSource) Schema(ctx context.Context, req datasource.Sch
 									Computed:            true,
 									CustomType:          supertypes.StringType{},
 								},
-								"comparison": schema.Int64Attribute{
+								"comparison": schema.Float64Attribute{
 									MarkdownDescription: "The value to compare against. Only available for types other than `anomaly_detection`.",
 									Computed:            true,
-									CustomType:          supertypes.Int64Type{},
 								},
 								"comparison_sensitivity": schema.StringAttribute{
 									MarkdownDescription: "Level of anomaly responsiveness. Higher thresholds means alerts for most anomalies. Lower thresholds means alerts only for larger ones. Only available for `anomaly_detection` type.",
@@ -267,7 +267,7 @@ type MetricMonitorDataSourceModelConditionGroup struct {
 
 type MetricMonitorDataSourceModelConditionGroupConditionsItem struct {
 	Type                    supertypes.StringValue `tfsdk:"type"`
-	Comparison              supertypes.Int64Value  `tfsdk:"comparison"`
+	Comparison              types.Float64          `tfsdk:"comparison"`
 	ComparisonSensitivity   supertypes.StringValue `tfsdk:"comparison_sensitivity"`
 	ComparisonThresholdType supertypes.StringValue `tfsdk:"comparison_threshold_type"`
 	ConditionResult         supertypes.Int64Value  `tfsdk:"condition_result"`

--- a/internal/provider/data_source_metric_monitor_impl.go
+++ b/internal/provider/data_source_metric_monitor_impl.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrydata"
 )
@@ -45,10 +46,8 @@ func (m *MetricMonitorDataSourceModel) fill(ctx context.Context, data apiclient.
 		outCondition.Type.Set(inCondition.Type)
 
 		if inComparison, err := inCondition.Comparison.AsProjectMonitorConditionGroupConditionComparison1(); err == nil {
-			if v, err := inComparison.Int64(); err == nil {
-				outCondition.Comparison.Set(v)
-			} else if v, err := inComparison.Float64(); err == nil {
-				outCondition.Comparison.Set(int64(v))
+			if v, err := inComparison.Float64(); err == nil {
+				outCondition.Comparison = types.Float64Value(v)
 			} else {
 				diags.AddError("Invalid comparison", "Unable to unmarshal comparison")
 				return

--- a/internal/provider/data_source_metric_monitor_test.go
+++ b/internal/provider/data_source_metric_monitor_test.go
@@ -75,12 +75,12 @@ func TestAccMetricMonitorDataSource_threshold(t *testing.T) {
 						"conditions": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("gt"),
-								"comparison":       knownvalue.Int64Exact(100),
+								"comparison":       knownvalue.Float64Exact(100),
 								"condition_result": knownvalue.Int64Exact(75),
 							}),
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("lte"),
-								"comparison":       knownvalue.Int64Exact(50),
+								"comparison":       knownvalue.Float64Exact(50),
 								"condition_result": knownvalue.Int64Exact(0),
 							}),
 						}),
@@ -136,12 +136,12 @@ func TestAccMetricMonitorDataSource_threshold(t *testing.T) {
 						"conditions": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("gt"),
-								"comparison":       knownvalue.Int64Exact(100),
+								"comparison":       knownvalue.Float64Exact(100),
 								"condition_result": knownvalue.Int64Exact(75),
 							}),
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("lte"),
-								"comparison":       knownvalue.Int64Exact(50),
+								"comparison":       knownvalue.Float64Exact(50),
 								"condition_result": knownvalue.Int64Exact(0),
 							}),
 						}),

--- a/internal/provider/resource_metric_monitor_gen.go
+++ b/internal/provider/resource_metric_monitor_gen.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrydata"
 	"github.com/jianyuan/terraform-provider-sentry/internal/tfutils"
 	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
@@ -215,13 +216,12 @@ func (r *MetricMonitorResource) Schema(ctx context.Context, req resource.SchemaR
 									},
 									sentrydata.DataConditionTypes,
 								),
-								"comparison": schema.Int64Attribute{
+								"comparison": schema.Float64Attribute{
 									MarkdownDescription: "The value to compare against. Only required for types other than `anomaly_detection`.",
 									Optional:            true,
-									CustomType:          supertypes.Int64Type{},
-									Validators: []validator.Int64{
-										fint64validator.NullIfAttributeIsOneOf(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("anomaly_detection")}),
-										fint64validator.RequireIfAttributeIsOneOf(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("eq"), supertypes.NewStringValue("gte"), supertypes.NewStringValue("gt"), supertypes.NewStringValue("lte"), supertypes.NewStringValue("lt"), supertypes.NewStringValue("ne")}),
+									Validators: []validator.Float64{
+										tfutils.NullIfAttributeIsOneOfFloat64(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("anomaly_detection")}),
+										tfutils.RequireIfAttributeIsOneOfFloat64(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("eq"), supertypes.NewStringValue("gte"), supertypes.NewStringValue("gt"), supertypes.NewStringValue("lte"), supertypes.NewStringValue("lt"), supertypes.NewStringValue("ne")}),
 									},
 								},
 								"comparison_sensitivity": tfutils.WithEnumStringAttribute(
@@ -435,7 +435,7 @@ type MetricMonitorResourceModelConditionGroup struct {
 
 type MetricMonitorResourceModelConditionGroupConditionsItem struct {
 	Type                    supertypes.StringValue `tfsdk:"type"`
-	Comparison              supertypes.Int64Value  `tfsdk:"comparison"`
+	Comparison              types.Float64          `tfsdk:"comparison"`
 	ComparisonSensitivity   supertypes.StringValue `tfsdk:"comparison_sensitivity"`
 	ComparisonThresholdType supertypes.StringValue `tfsdk:"comparison_threshold_type"`
 	ConditionResult         supertypes.Int64Value  `tfsdk:"condition_result"`

--- a/internal/provider/resource_metric_monitor_impl.go
+++ b/internal/provider/resource_metric_monitor_impl.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/go-utils/must"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrydata"
@@ -74,7 +75,8 @@ func (r *MetricMonitorResource) getCreateJSONRequestBody(ctx context.Context, da
 				return nil, diags
 			}
 		} else {
-			if err := outComparison.FromProjectMonitorConditionGroupConditionComparison1(json.Number(strconv.FormatInt(inCondition.Comparison.Get(), 10))); err != nil {
+			// Format as a JSON number so integers stay integer-shaped (100, not 100.0).
+			if err := outComparison.FromProjectMonitorConditionGroupConditionComparison1(json.Number(strconv.FormatFloat(inCondition.Comparison.ValueFloat64(), 'f', -1, 64))); err != nil {
 				diags.AddError("Error marshalling JSON", err.Error())
 				return nil, diags
 			}
@@ -209,10 +211,8 @@ func (m *MetricMonitorResourceModel) Fill(ctx context.Context, data apiclient.Pr
 		outCondition.Type.Set(inCondition.Type)
 
 		if inComparison, err := inCondition.Comparison.AsProjectMonitorConditionGroupConditionComparison1(); err == nil {
-			if v, err := inComparison.Int64(); err == nil {
-				outCondition.Comparison.Set(v)
-			} else if v, err := inComparison.Float64(); err == nil {
-				outCondition.Comparison.Set(int64(v))
+			if v, err := inComparison.Float64(); err == nil {
+				outCondition.Comparison = types.Float64Value(v)
 			} else {
 				diags.AddError("Invalid comparison", "Unable to unmarshal comparison")
 				return

--- a/internal/provider/resource_metric_monitor_test.go
+++ b/internal/provider/resource_metric_monitor_test.go
@@ -147,12 +147,12 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 						"conditions": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("gt"),
-								"comparison":       knownvalue.Int64Exact(100),
+								"comparison":       knownvalue.Float64Exact(100),
 								"condition_result": knownvalue.Int64Exact(75),
 							}),
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("lte"),
-								"comparison":       knownvalue.Int64Exact(50),
+								"comparison":       knownvalue.Float64Exact(50),
 								"condition_result": knownvalue.Int64Exact(0),
 							}),
 						}),
@@ -208,12 +208,12 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 						"conditions": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("gt"),
-								"comparison":       knownvalue.Int64Exact(100),
+								"comparison":       knownvalue.Float64Exact(100),
 								"condition_result": knownvalue.Int64Exact(75),
 							}),
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("lte"),
-								"comparison":       knownvalue.Int64Exact(50),
+								"comparison":       knownvalue.Float64Exact(50),
 								"condition_result": knownvalue.Int64Exact(0),
 							}),
 						}),
@@ -365,17 +365,17 @@ func TestAccMetricMonitorResource_change(t *testing.T) {
 						"conditions": knownvalue.ListExact([]knownvalue.Check{
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("lt"),
-								"comparison":       knownvalue.Int64Exact(50),
+								"comparison":       knownvalue.Float64Exact(50),
 								"condition_result": knownvalue.Int64Exact(75),
 							}),
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("lt"),
-								"comparison":       knownvalue.Int64Exact(100),
+								"comparison":       knownvalue.Float64Exact(100),
 								"condition_result": knownvalue.Int64Exact(50),
 							}),
 							knownvalue.ObjectPartial(map[string]knownvalue.Check{
 								"type":             knownvalue.StringExact("gte"),
-								"comparison":       knownvalue.Int64Exact(100),
+								"comparison":       knownvalue.Float64Exact(100),
 								"condition_result": knownvalue.Int64Exact(0),
 							}),
 						}),
@@ -466,6 +466,98 @@ func TestAccMetricMonitorResource_dynamic(t *testing.T) {
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("issue_detection"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"type":             knownvalue.StringExact("dynamic"),
+						"comparison_delta": knownvalue.Null(),
+					})),
+				),
+			},
+			{
+				ResourceName:            rn,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"query_type"},
+			},
+		},
+	})
+}
+
+func TestAccMetricMonitorResource_fractionalComparison(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("tf-project")
+	monitorName := acctest.RandomWithPrefix("tf-metric-monitor")
+	rn := "sentry_metric_monitor.test"
+
+	checks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("organization"), knownvalue.StringExact(acctest.TestOrganization)),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("project"), knownvalue.NotNull()),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("owner"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+			"user_id": knownvalue.Null(),
+			"team_id": knownvalue.NotNull(),
+		})),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetricMonitorResourceConfig(projectName, monitorName, `
+					aggregate = "count()"
+					dataset = "events"
+					event_types = ["default", "error"]
+					query = "is:unresolved"
+					query_type = "error"
+					time_window_seconds = 3600
+
+					condition_group = {
+						conditions = [
+							{
+								type = "gt"
+								comparison = 0.5
+								condition_result = 75
+							},
+							{
+								type = "lte"
+								comparison = 0.07
+								condition_result = 0
+							},
+						]
+					}
+
+					issue_detection = {
+						type = "static"
+					}
+				`),
+				ConfigStateChecks: append(
+					checks,
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("aggregate"), knownvalue.StringExact("count()")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("dataset"), knownvalue.StringExact("events")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("event_types"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("default"),
+						knownvalue.StringExact("error"),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.StringExact("is:unresolved")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(3600)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"logic_type": knownvalue.StringExact("any"),
+						"conditions": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("gt"),
+								"comparison":       knownvalue.Float64Exact(0.5),
+								"condition_result": knownvalue.Int64Exact(75),
+							}),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("lte"),
+								"comparison":       knownvalue.Float64Exact(0.07),
+								"condition_result": knownvalue.Int64Exact(0),
+							}),
+						}),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("issue_detection"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"type":             knownvalue.StringExact("static"),
 						"comparison_delta": knownvalue.Null(),
 					})),
 				),

--- a/internal/providergen/data_sources/metric_monitor.ts
+++ b/internal/providergen/data_sources/metric_monitor.ts
@@ -188,7 +188,7 @@ export default {
             },
             {
               name: "comparison",
-              type: "int",
+              type: "float64",
               description:
                 "The value to compare against. Only available for types other than `anomaly_detection`.",
               computedOptionalRequired: "computed",

--- a/internal/providergen/index.ts
+++ b/internal/providergen/index.ts
@@ -108,6 +108,32 @@ function generateTerraformAttribute({
       }
       return parts.join("\n");
     })
+    .with({ type: "float64" }, (attribute) => {
+      const parts: string[] = [];
+      parts.push("schema.Float64Attribute{");
+      parts.push(...commonParts);
+      // Plain basetypes here, not supertypes.Float64Value: the supertypes wrapper inherits
+      // basetypes' Float64SemanticEquals without overriding it, so its type assertion rejects
+      // the wrapper on every plan (hashicorp/terraform-plugin-framework#786). Float64 is the
+      // only type this hits — Int64/String/Bool have no SemanticEquals to inherit.
+      if (attribute.customType) {
+        parts.push(`CustomType: ${attribute.customType.type},`);
+      }
+      if (attribute.validators) {
+        parts.push("Validators: []validator.Float64{");
+        parts.push(...attribute.validators.map((validator) => `${validator},`));
+        parts.push("},");
+      }
+      if (attribute.planModifiers) {
+        parts.push("PlanModifiers: []planmodifier.Float64{");
+        parts.push(
+          ...attribute.planModifiers.map((modifier) => `${modifier},`),
+        );
+        parts.push("},");
+      }
+      parts.push("}");
+      return parts.join("\n");
+    })
     .with({ type: "bool" }, () => {
       const parts: string[] = [];
       parts.push("schema.BoolAttribute{");
@@ -315,6 +341,7 @@ function generateTerraformValueType({
     )
     .with({ type: "string" }, () => "supertypes.StringValue")
     .with({ type: "int" }, () => "supertypes.Int64Value")
+    .with({ type: "float64" }, () => "types.Float64")
     .with({ type: "bool" }, () => "supertypes.BoolValue")
     .with(
       { type: "list", elementType: "string" },
@@ -360,6 +387,7 @@ function generateTerraformToPrimitive({
   return match(attribute)
     .with({ type: "string" }, () => `${srcVarName}.ValueString()`)
     .with({ type: "int" }, () => `${srcVarName}.ValueInt64()`)
+    .with({ type: "float64" }, () => `${srcVarName}.ValueFloat64()`)
     .with({ type: "bool" }, () => `${srcVarName}.ValueBool()`)
     .exhaustive();
 }
@@ -410,6 +438,10 @@ function generatePrimitiveToTerraform({
     .with(
       { type: "int" },
       () => `${destVarName} = supertypes.NewInt64Value(${srcVarName})`,
+    )
+    .with(
+      { type: "float64" },
+      () => `${destVarName} = types.Float64Value(${srcVarName})`,
     )
     .with(
       { type: "bool" },

--- a/internal/providergen/resources/metric_monitor.ts
+++ b/internal/providergen/resources/metric_monitor.ts
@@ -210,13 +210,13 @@ export default {
             },
             {
               name: "comparison",
-              type: "int",
+              type: "float64",
               description:
                 "The value to compare against. Only required for types other than `anomaly_detection`.",
               computedOptionalRequired: "optional",
               validators: [
-                `fint64validator.NullIfAttributeIsOneOf(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("anomaly_detection")})`,
-                `fint64validator.RequireIfAttributeIsOneOf(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("eq"), supertypes.NewStringValue("gte"), supertypes.NewStringValue("gt"), supertypes.NewStringValue("lte"), supertypes.NewStringValue("lt"), supertypes.NewStringValue("ne")})`,
+                `tfutils.NullIfAttributeIsOneOfFloat64(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("anomaly_detection")})`,
+                `tfutils.RequireIfAttributeIsOneOfFloat64(path.MatchRelative().AtParent().AtName("type"), []attr.Value{supertypes.NewStringValue("eq"), supertypes.NewStringValue("gte"), supertypes.NewStringValue("gt"), supertypes.NewStringValue("lte"), supertypes.NewStringValue("lt"), supertypes.NewStringValue("ne")})`,
               ],
             },
             {

--- a/internal/providergen/schema.ts
+++ b/internal/providergen/schema.ts
@@ -7,6 +7,7 @@ export type ComputedOptionalRequired =
 export type Attribute =
   | StringAttribute
   | IntAttribute
+  | Float64Attribute
   | BoolAttribute
   | ListAttribute
   | ListNestedAttribute
@@ -44,6 +45,10 @@ export interface StringAttribute extends BaseAttribute {
 
 export interface IntAttribute extends BaseAttribute {
   type: "int";
+}
+
+export interface Float64Attribute extends BaseAttribute {
+  type: "float64";
 }
 
 export interface BoolAttribute extends BaseAttribute {

--- a/internal/tfutils/float64_conditional_validators.go
+++ b/internal/tfutils/float64_conditional_validators.go
@@ -1,0 +1,120 @@
+package tfutils
+
+// Float64 variants of orange-cloudavenue's Null/RequireIfAttributeIsOneOf,
+// which the library only ships for Int64.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// NullIfAttributeIsOneOfFloat64 ensures the float64 attribute is null when the
+// referenced attribute has one of the given values.
+func NullIfAttributeIsOneOfFloat64(p path.Expression, exceptedValues []attr.Value) validator.Float64 {
+	return nullIfOneOfFloat64{path: p, exceptedValues: exceptedValues}
+}
+
+type nullIfOneOfFloat64 struct {
+	path           path.Expression
+	exceptedValues []attr.Value
+}
+
+func (v nullIfOneOfFloat64) Description(_ context.Context) string {
+	return fmt.Sprintf("must be null when %s is one of %v", v.path, v.exceptedValues)
+}
+
+func (v nullIfOneOfFloat64) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v nullIfOneOfFloat64) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	paths, diags := req.Config.PathMatches(ctx, req.PathExpression.Merge(v.path))
+	resp.Diagnostics.Append(diags...)
+	if diags.HasError() {
+		return
+	}
+	for _, p := range paths {
+		var other attr.Value
+		d := req.Config.GetAttribute(ctx, p, &other)
+		resp.Diagnostics.Append(d...)
+		if d.HasError() {
+			return
+		}
+		if other.IsNull() || other.IsUnknown() {
+			continue
+		}
+		for _, ex := range v.exceptedValues {
+			if other.Equal(ex) {
+				resp.Diagnostics.AddAttributeError(
+					req.Path,
+					"Invalid attribute combination",
+					fmt.Sprintf("Attribute must be null when %s is %s.", p, ex),
+				)
+				return
+			}
+		}
+	}
+}
+
+// RequireIfAttributeIsOneOfFloat64 ensures the float64 attribute is set when the
+// referenced attribute has one of the given values.
+func RequireIfAttributeIsOneOfFloat64(p path.Expression, requiredValues []attr.Value) validator.Float64 {
+	return requireIfOneOfFloat64{path: p, requiredValues: requiredValues}
+}
+
+type requireIfOneOfFloat64 struct {
+	path           path.Expression
+	requiredValues []attr.Value
+}
+
+func (v requireIfOneOfFloat64) Description(_ context.Context) string {
+	return fmt.Sprintf("must be set when %s is one of %v", v.path, v.requiredValues)
+}
+
+func (v requireIfOneOfFloat64) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v requireIfOneOfFloat64) ValidateFloat64(ctx context.Context, req validator.Float64Request, resp *validator.Float64Response) {
+	if !req.ConfigValue.IsNull() {
+		return
+	}
+	paths, ds := req.Config.PathMatches(ctx, req.PathExpression.Merge(v.path))
+	resp.Diagnostics.Append(ds...)
+	if ds.HasError() {
+		return
+	}
+	for _, p := range paths {
+		var other attr.Value
+		d := req.Config.GetAttribute(ctx, p, &other)
+		resp.Diagnostics.Append(d...)
+		if d.HasError() {
+			return
+		}
+		if other.IsNull() || other.IsUnknown() {
+			continue
+		}
+		for _, want := range v.requiredValues {
+			if other.Equal(want) {
+				resp.Diagnostics.AddAttributeError(
+					req.Path,
+					"Missing required attribute",
+					fmt.Sprintf("Attribute must be set when %s is %s.", p, want),
+				)
+				return
+			}
+		}
+	}
+}
+
+var (
+	_ validator.Float64 = nullIfOneOfFloat64{}
+	_ validator.Float64 = requireIfOneOfFloat64{}
+)


### PR DESCRIPTION
The comparison attribute was Int64, which truncated fractional thresholds (crash-rate, CLS, Apdex — e.g. 0.5) to integers on both read and write. Make it Float64.

Use the framework's types.Float64 rather than supertypes.Float64Value. The supertypes wrapper embeds basetypes.Float64Value and inherits its Float64SemanticEquals without overriding it, so the inherited type assertion rejects the wrapper and every plan errors with "Expected basetypes.Float64Value, Got supertypes.Float64Value". Float64 is the only type this affects — Int64/String/Bool have no SemanticEquals to inherit. Ref hashicorp/terraform-plugin-framework#786.