### PR TITLE
feat(alert): add webhook action to sentry_alert

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -919,6 +919,7 @@ Optional:
 - `sentry_app` (Attributes) Trigger an action in a Sentry App (e.g. Rootly). (see [below for nested schema](#nestedatt--action_filters--actions--sentry_app))
 - `slack` (Attributes) Notify on Slack. (see [below for nested schema](#nestedatt--action_filters--actions--slack))
 - `vsts` (Attributes) Notify on Azure DevOps. (see [below for nested schema](#nestedatt--action_filters--actions--vsts))
+- `webhook` (Attributes) Send a notification via a legacy integration service (e.g. an internal integration's webhook). This is the successor to the `notify_event_service` action on the legacy `sentry_issue_alert` resource. (see [below for nested schema](#nestedatt--action_filters--actions--webhook))
 
 <a id="nestedatt--action_filters--actions--discord"></a>
 ### Nested Schema for `action_filters.actions.discord`
@@ -1064,6 +1065,14 @@ Required:
 - `integration_id` (String) The ID of the OpsGenie integration.
 - `project` (String) The ID of the Azure DevOps project.
 - `work_item_type` (String) The type of work item to create.
+
+
+<a id="nestedatt--action_filters--actions--webhook"></a>
+### Nested Schema for `action_filters.actions.webhook`
+
+Required:
+
+- `service` (String) The slug of the integration service to notify. Use the special value `webhooks` to notify all legacy plugin webhooks.
 
 
 

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -3577,6 +3577,7 @@ components:
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_JiraServer"
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_GitHub"
         - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_SentryApp"
+        - $ref: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_Webhook"
       discriminator:
         propertyName: type
         mapping:
@@ -3592,6 +3593,7 @@ components:
           jira_server: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_JiraServer"
           github: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_GitHub"
           sentry_app: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_SentryApp"
+          webhook: "#/components/schemas/OrganizationWorkflow_ActionFilter_Action_Webhook"
     OrganizationWorkflow_ActionFilter_Action_Email:
       type: object
       required:
@@ -4011,6 +4013,26 @@ components:
             targetIdentifier:
               type: string
             targetDisplay:
+              type: string
+    OrganizationWorkflow_ActionFilter_Action_Webhook:
+      type: object
+      required:
+        - type
+        - config
+        - data
+      properties:
+        type:
+          type: string
+          enum:
+            - webhook
+        data:
+          type: object
+        config:
+          type: object
+          required:
+            - targetIdentifier
+          properties:
+            targetIdentifier:
               type: string
     OrganizationWorkflow_ActionFilter_Condition_IssueType:
       type: object

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -449,6 +449,21 @@ func (e OrganizationWorkflowActionFilterActionVstsType) Valid() bool {
 	}
 }
 
+// Defines values for OrganizationWorkflowActionFilterActionWebhookType.
+const (
+	Webhook OrganizationWorkflowActionFilterActionWebhookType = "webhook"
+)
+
+// Valid indicates whether the value is a known member of the OrganizationWorkflowActionFilterActionWebhookType enum.
+func (e OrganizationWorkflowActionFilterActionWebhookType) Valid() bool {
+	switch e {
+	case Webhook:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for OrganizationWorkflowActionFilterConditionAgeComparisonComparisonComparisonType.
 const (
 	Newer OrganizationWorkflowActionFilterConditionAgeComparisonComparisonComparisonType = "newer"
@@ -1869,6 +1884,18 @@ type OrganizationWorkflowActionFilterActionVstsConfigTargetType string
 
 // OrganizationWorkflowActionFilterActionVstsType defines model for OrganizationWorkflowActionFilterActionVsts.Type.
 type OrganizationWorkflowActionFilterActionVstsType string
+
+// OrganizationWorkflowActionFilterActionWebhook defines model for OrganizationWorkflow_ActionFilter_Action_Webhook.
+type OrganizationWorkflowActionFilterActionWebhook struct {
+	Config struct {
+		TargetIdentifier string `json:"targetIdentifier"`
+	} `json:"config"`
+	Data map[string]interface{}                            `json:"data"`
+	Type OrganizationWorkflowActionFilterActionWebhookType `json:"type"`
+}
+
+// OrganizationWorkflowActionFilterActionWebhookType defines model for OrganizationWorkflowActionFilterActionWebhook.Type.
+type OrganizationWorkflowActionFilterActionWebhookType string
 
 // OrganizationWorkflowActionFilterCondition defines model for OrganizationWorkflow_ActionFilter_Condition.
 type OrganizationWorkflowActionFilterCondition struct {
@@ -3929,6 +3956,34 @@ func (t *OrganizationWorkflowActionFilterAction) MergeOrganizationWorkflowAction
 	return err
 }
 
+// AsOrganizationWorkflowActionFilterActionWebhook returns the union data inside the OrganizationWorkflowActionFilterAction as a OrganizationWorkflowActionFilterActionWebhook
+func (t OrganizationWorkflowActionFilterAction) AsOrganizationWorkflowActionFilterActionWebhook() (OrganizationWorkflowActionFilterActionWebhook, error) {
+	var body OrganizationWorkflowActionFilterActionWebhook
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromOrganizationWorkflowActionFilterActionWebhook overwrites any union data inside the OrganizationWorkflowActionFilterAction as the provided OrganizationWorkflowActionFilterActionWebhook
+func (t *OrganizationWorkflowActionFilterAction) FromOrganizationWorkflowActionFilterActionWebhook(v OrganizationWorkflowActionFilterActionWebhook) error {
+	v.Type = "webhook"
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeOrganizationWorkflowActionFilterActionWebhook performs a merge with any union data inside the OrganizationWorkflowActionFilterAction, using the provided OrganizationWorkflowActionFilterActionWebhook
+func (t *OrganizationWorkflowActionFilterAction) MergeOrganizationWorkflowActionFilterActionWebhook(v OrganizationWorkflowActionFilterActionWebhook) error {
+	v.Type = "webhook"
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
 func (t OrganizationWorkflowActionFilterAction) Discriminator() (string, error) {
 	var discriminator struct {
 		Discriminator string `json:"type"`
@@ -3967,6 +4022,8 @@ func (t OrganizationWorkflowActionFilterAction) ValueByDiscriminator() (interfac
 		return t.AsOrganizationWorkflowActionFilterActionSlack()
 	case "vsts":
 		return t.AsOrganizationWorkflowActionFilterActionVsts()
+	case "webhook":
+		return t.AsOrganizationWorkflowActionFilterActionWebhook()
 	default:
 		return nil, errors.New("unknown discriminator value: " + discriminator)
 	}

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -738,7 +738,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemEmail](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"target_type": tfutils.WithEnumStringAttribute(
@@ -777,7 +777,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemPlugin](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{},
 									},
@@ -786,7 +786,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemSlack](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -823,7 +823,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemPagerduty](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -853,7 +853,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemDiscord](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -878,7 +878,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemMsteams](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -903,7 +903,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemOpsgenie](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -933,7 +933,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemVsts](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -958,7 +958,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemJira](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -983,7 +983,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemJiraServer](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -1008,7 +1008,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemGithub](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("sentry_app")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("sentry_app"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"integration_id": schema.StringAttribute{
@@ -1038,7 +1038,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										Optional:            true,
 										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemSentryApp](ctx),
 										Validators: []validator.Object{
-											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github")),
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("webhook")),
 										},
 										Attributes: map[string]schema.Attribute{
 											"sentry_app_id": schema.StringAttribute{
@@ -1070,6 +1070,21 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 														},
 													},
 												},
+											},
+										},
+									},
+									"webhook": schema.SingleNestedAttribute{
+										MarkdownDescription: "Send a notification via a legacy integration service (e.g. an internal integration's webhook). This is the successor to the `notify_event_service` action on the legacy `sentry_issue_alert` resource.",
+										Optional:            true,
+										CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelActionFiltersItemActionsItemWebhook](ctx),
+										Validators: []validator.Object{
+											objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("email"), path.MatchRelative().AtParent().AtName("plugin"), path.MatchRelative().AtParent().AtName("slack"), path.MatchRelative().AtParent().AtName("pagerduty"), path.MatchRelative().AtParent().AtName("discord"), path.MatchRelative().AtParent().AtName("msteams"), path.MatchRelative().AtParent().AtName("opsgenie"), path.MatchRelative().AtParent().AtName("vsts"), path.MatchRelative().AtParent().AtName("jira"), path.MatchRelative().AtParent().AtName("jira_server"), path.MatchRelative().AtParent().AtName("github"), path.MatchRelative().AtParent().AtName("sentry_app")),
+										},
+										Attributes: map[string]schema.Attribute{
+											"service": schema.StringAttribute{
+												MarkdownDescription: "The slug of the integration service to notify. Use the special value `webhooks` to notify all legacy plugin webhooks.",
+												Required:            true,
+												CustomType:          supertypes.StringType{},
 											},
 										},
 									},
@@ -1414,6 +1429,7 @@ type AlertResourceModelActionFiltersItemActionsItem struct {
 	JiraServer supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemJiraServer] `tfsdk:"jira_server"`
 	Github     supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemGithub]     `tfsdk:"github"`
 	SentryApp  supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemSentryApp]  `tfsdk:"sentry_app"`
+	Webhook    supertypes.SingleNestedObjectValueOf[AlertResourceModelActionFiltersItemActionsItemWebhook]    `tfsdk:"webhook"`
 }
 
 type AlertResourceModelActionFiltersItemActionsItemEmail struct {
@@ -1493,4 +1509,8 @@ type AlertResourceModelActionFiltersItemActionsItemSentryAppSettingsItem struct 
 	Name  supertypes.StringValue `tfsdk:"name"`
 	Value supertypes.StringValue `tfsdk:"value"`
 	Label supertypes.StringValue `tfsdk:"label"`
+}
+
+type AlertResourceModelActionFiltersItemActionsItemWebhook struct {
+	Service supertypes.StringValue `tfsdk:"service"`
 }

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -621,6 +621,21 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 					return nil, diags
 				}
 
+			case inAction.Webhook.IsKnown():
+				inWebhook := inAction.Webhook.DiagsGet(ctx, diags)
+				if diags.HasError() {
+					return nil, diags
+				}
+
+				var outWebhook apiclient.OrganizationWorkflowActionFilterActionWebhook
+				outWebhook.Data = map[string]any{}
+				outWebhook.Config.TargetIdentifier = inWebhook.Service.Get()
+
+				if err := outAction.FromOrganizationWorkflowActionFilterActionWebhook(outWebhook); err != nil {
+					diags.AddError("Failed to create action", err.Error())
+					return nil, diags
+				}
+
 			}
 
 			outActions = append(outActions, outAction)
@@ -1071,6 +1086,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				JiraServer: supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemJiraServer](ctx),
 				Github:     supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemGithub](ctx),
 				SentryApp:  supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemSentryApp](ctx),
+				Webhook:    supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelActionFiltersItemActionsItemWebhook](ctx),
 			}
 
 			actionValue, err := action.ValueByDiscriminator()
@@ -1201,6 +1217,12 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				}
 
 				outAction.SentryApp = supertypes.NewSingleNestedObjectValueOf(ctx, &outSentryApp)
+
+			case apiclient.OrganizationWorkflowActionFilterActionWebhook:
+				var outWebhook AlertResourceModelActionFiltersItemActionsItemWebhook
+				outWebhook.Service = supertypes.NewStringValue(actionValue.Config.TargetIdentifier)
+
+				outAction.Webhook = supertypes.NewSingleNestedObjectValueOf(ctx, &outWebhook)
 			}
 
 			if diags.HasError() {

--- a/internal/provider/resource_alert_test.go
+++ b/internal/provider/resource_alert_test.go
@@ -522,6 +522,11 @@ func testAccAlertResourceConfig(projectName, monitorName, name, opsgenieTeamName
 								labels         = ["bug"]
 							}
 						},
+						{
+							webhook = {
+								service = "terraform-provider-sentry-ea4fdd"
+							}
+						},
 					]
 				}
 			]

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -1071,6 +1071,22 @@ export default {
                 },
               ],
             },
+            {
+              name: "webhook",
+              type: "single_nested",
+              description:
+                "Send a notification via a legacy integration service (e.g. an internal integration's webhook). This is the successor to the `notify_event_service` action on the legacy `sentry_issue_alert` resource.",
+              computedOptionalRequired: "optional",
+              attributes: [
+                {
+                  name: "service",
+                  type: "string",
+                  description:
+                    "The slug of the integration service to notify. Use the special value `webhooks` to notify all legacy plugin webhooks.",
+                  computedOptionalRequired: "required",
+                },
+              ],
+            },
           ]),
         },
       ],


### PR DESCRIPTION
## Summary

Adds first-class support for the **`webhook`** action to the `sentry_alert` resource. This is the Workflow Engine equivalent of the legacy `sentry_issue_alert` `notify_event_service` action (used by internal integrations / Sentry App webhook services).

In the Workflow Engine API that backs `sentry_alert`, this action serializes as:

```json
{
  "type": "webhook",
  "integrationId": null,
  "data": {},
  "config": { "targetType": null, "targetDisplay": null, "targetIdentifier": "<service-slug>" }
}
```

where `config.targetIdentifier` carries the same slug the legacy action stored in its `service` field.

## Motivation

The provider had no equivalent for this action, so internal-integration webhook services could only be (incorrectly) expressed via `sentry_app`, which Sentry rejects with:

> Unknown integration - The integration is no longer available. Please remove and reconfigure this action.

Additionally, **reading** any workflow that already contained a `webhook` action failed with `unknown discriminator value: webhook` (no `default` case in the read switch), breaking import/refresh of those alerts.

## Changes

- **`internal/apiclient/api.yaml`** — new `OrganizationWorkflow_ActionFilter_Action_Webhook` variant registered in the action union `oneOf` + discriminator `mapping`.
- **`internal/providergen/resources/alert.ts`** — `webhook` action with a single required `service` attribute.
- **`internal/provider/resource_alert_impl.go`** — read/write conversion mapping `service` ⇄ `config.targetIdentifier`.
- Regenerated `apiclient.gen.go`, `resource_alert_gen.go`, and `docs/resources/alert.md`.
- Added `webhook` coverage to the alert acceptance test.

## Validation

Cross-checked against the Sentry source (`workflow_engine` action registry and `webhook_handler` config schema):
- `Action.Type.WEBHOOK = "webhook"`.
- Legacy mapping: `WEBHOOK → id="sentry.rules.actions.notify_event_service.NotifyEventServiceAction", target_identifier_key="service"`.
- Webhook config schema carries only `target_identifier` (string); `target_type`/`target_display` are constrained to `null` and `data` is `{}` — hence a single `service` field, sending neither targetType nor targetDisplay.

## Example

```hcl
action_filters = [{
  logic_type = "all"
  actions = [{
    webhook = {
      service = "my-internal-integration-slug"
    }
  }]
}]
```

## Test plan

- [x] `go build ./...`, `go vet ./...`, test compilation pass.
- [ ] Acceptance test (`TestAccAlertResource_basic`) — requires `TF_ACC=1` and a live org with the referenced internal-integration slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)