### PR TITLE
fix(sentry_metric_monitor): support float values in metric_monitor comparison field

### DIFF
--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -2908,8 +2908,7 @@ components:
         comparison:
           oneOf:
             - type: string
-            - type: integer
-              format: int64
+            - type: number
               x-go-type: json.Number
             - type: object
               required:

--- a/internal/apiclient/comparison_test.go
+++ b/internal/apiclient/comparison_test.go
@@ -1,0 +1,93 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProjectMonitorConditionGroupCondition_FloatComparison(t *testing.T) {
+	testCases := []struct {
+		name     string
+		jsonData string
+		expected float64
+	}{
+		{
+			name:     "integer comparison",
+			jsonData: `{"type":"gt","comparison":100,"conditionResult":75}`,
+			expected: 100,
+		},
+		{
+			name:     "float comparison - 0.25",
+			jsonData: `{"type":"gt","comparison":0.25,"conditionResult":75}`,
+			expected: 0.25,
+		},
+		{
+			name:     "float comparison - 0.1",
+			jsonData: `{"type":"gt","comparison":0.1,"conditionResult":50}`,
+			expected: 0.1,
+		},
+		{
+			name:     "small float comparison - 0.07",
+			jsonData: `{"type":"gt","comparison":0.07,"conditionResult":75}`,
+			expected: 0.07,
+		},
+		{
+			name:     "negative float comparison",
+			jsonData: `{"type":"gt","comparison":-0.5,"conditionResult":75}`,
+			expected: -0.5,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var condition ProjectMonitorConditionGroupCondition
+			err := json.Unmarshal([]byte(tc.jsonData), &condition)
+			if err != nil {
+				t.Fatalf("failed to unmarshal JSON: %v", err)
+			}
+
+			comparison, err := condition.Comparison.AsProjectMonitorConditionGroupConditionComparison1()
+			if err != nil {
+				t.Fatalf("failed to get comparison as number: %v", err)
+			}
+
+			floatValue, err := comparison.Float64()
+			if err != nil {
+				t.Fatalf("failed to convert to float64: %v", err)
+			}
+
+			if floatValue != tc.expected {
+				t.Errorf("expected %f, got %f", tc.expected, floatValue)
+			}
+		})
+	}
+}
+
+func TestProjectMonitorConditionGroupCondition_AnomalyDetection(t *testing.T) {
+	jsonData := `{"type":"anomaly_detection","comparison":{"seasonality":"auto","sensitivity":"high","thresholdType":0},"conditionResult":75}`
+
+	var condition ProjectMonitorConditionGroupCondition
+	err := json.Unmarshal([]byte(jsonData), &condition)
+	if err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
+	}
+
+	// This should fail for number comparison
+	_, err = condition.Comparison.AsProjectMonitorConditionGroupConditionComparison1()
+	if err == nil {
+		t.Error("expected error when trying to get anomaly detection as number")
+	}
+
+	// This should succeed for object comparison
+	comparison, err := condition.Comparison.AsProjectMonitorConditionGroupConditionComparison2()
+	if err != nil {
+		t.Fatalf("failed to get comparison as object: %v", err)
+	}
+
+	if comparison.Sensitivity != "high" {
+		t.Errorf("expected sensitivity 'high', got %q", comparison.Sensitivity)
+	}
+	if comparison.Seasonality != "auto" {
+		t.Errorf("expected seasonality 'auto', got %q", comparison.Seasonality)
+	}
+}

--- a/internal/provider/resource_cron_monitor_impl.go
+++ b/internal/provider/resource_cron_monitor_impl.go
@@ -89,12 +89,11 @@ func (r *CronMonitorResource) getCreateJSONRequestBody(ctx context.Context, data
 			return nil, diags
 		}
 
-		switch {
-		case owner.TeamId.IsKnown():
+		if owner.TeamId.IsKnown() {
 			out.Owner.Set(fmt.Sprintf("team:%s", owner.TeamId.Get()))
-		case owner.UserId.IsKnown():
+		} else if owner.UserId.IsKnown() {
 			out.Owner.Set(fmt.Sprintf("user:%s", owner.UserId.Get()))
-		default:
+		} else {
 			out.Owner.SetNull()
 		}
 	} else {

--- a/internal/provider/resource_metric_monitor_impl.go
+++ b/internal/provider/resource_metric_monitor_impl.go
@@ -18,38 +18,43 @@ import (
 func (r *MetricMonitorResource) getCreateJSONRequestBody(ctx context.Context, data MetricMonitorResourceModel) (*apiclient.CreateProjectMonitorJSONRequestBody, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	outDs := apiclient.ProjectMonitorDataSourceSnubaQuerySubscription{
-		Aggregate:  data.Aggregate.Get(),
-		Dataset:    data.Dataset.Get(),
-		EventTypes: tfutils.MergeDiagnostics(data.EventTypes.Get(ctx))(&diags),
+	outDs := apiclient.ProjectMonitorDataSourceSnubaQuerySubscription{}
+	outDs.Aggregate = data.Aggregate.Get()
+	outDs.Dataset = data.Dataset.Get()
+
+	outDs.EventTypes = tfutils.MergeDiagnostics(data.EventTypes.Get(ctx))(&diags)
+	if diags.HasError() {
+		return nil, diags
 	}
+
 	if data.Environment.IsKnown() {
 		outDs.Environment.Set(data.Environment.Get())
 	} else {
 		outDs.Environment.SetNull()
 	}
+
 	if data.Query.IsKnown() {
 		outDs.Query.Set(data.Query.Get())
 	} else {
 		outDs.Query.SetUnspecified()
 	}
+
 	if data.QueryType.IsKnown() {
 		outDs.QueryType.Set(sentrydata.SnubaQueryTypeNameToId[data.QueryType.Get()])
 	} else {
 		outDs.QueryType.SetUnspecified()
 	}
+
 	if data.TimeWindowSeconds.IsKnown() {
 		outDs.TimeWindow.Set(data.TimeWindowSeconds.Get())
 	} else {
 		outDs.TimeWindow.SetUnspecified()
 	}
+
 	if data.ExtrapolationMode.IsKnown() {
 		outDs.ExtrapolationMode.Set(data.ExtrapolationMode.Get())
 	} else {
 		outDs.ExtrapolationMode.SetNull()
-	}
-	if diags.HasError() {
-		return nil, diags
 	}
 
 	inConditionGroup := tfutils.MergeDiagnostics(data.ConditionGroup.Get(ctx))(&diags)
@@ -62,9 +67,10 @@ func (r *MetricMonitorResource) getCreateJSONRequestBody(ctx context.Context, da
 		return nil, diags
 	}
 
-	outConditions := make([]apiclient.ProjectMonitorConditionGroupCondition, 0, len(inConditions))
-	for _, inCondition := range inConditions {
+	outConditions := make([]apiclient.ProjectMonitorConditionGroupCondition, len(inConditions))
+	for i, inCondition := range inConditions {
 		var outComparison apiclient.ProjectMonitorConditionGroupCondition_Comparison
+
 		if inCondition.Type.Get() == "anomaly_detection" {
 			if err := outComparison.FromProjectMonitorConditionGroupConditionComparison2(apiclient.ProjectMonitorConditionGroupConditionComparison2{
 				Seasonality:   "auto",
@@ -82,11 +88,11 @@ func (r *MetricMonitorResource) getCreateJSONRequestBody(ctx context.Context, da
 			}
 		}
 
-		outConditions = append(outConditions, apiclient.ProjectMonitorConditionGroupCondition{
+		outConditions[i] = apiclient.ProjectMonitorConditionGroupCondition{
 			Type:            inCondition.Type.Get(),
 			Comparison:      outComparison,
 			ConditionResult: inCondition.ConditionResult.Get(),
-		})
+		}
 	}
 
 	inConfig := tfutils.MergeDiagnostics(data.IssueDetection.Get(ctx))(&diags)
@@ -103,18 +109,15 @@ func (r *MetricMonitorResource) getCreateJSONRequestBody(ctx context.Context, da
 		return nil, diags
 	}
 
-	out := apiclient.ProjectMonitorRequestMetricIssue{
-		Name:      data.Name.Get(),
-		ProjectId: data.Project.Get(),
-		DataSources: []apiclient.ProjectMonitorDataSourceSnubaQuerySubscription{
-			outDs,
-		},
-		ConditionGroup: apiclient.ProjectMonitorConditionGroup{
-			LogicType:  apiclient.ProjectMonitorConditionGroupLogicType(inConditionGroup.LogicType.Get()),
-			Conditions: outConditions,
-		},
-		Config: &outConfig,
+	out := apiclient.ProjectMonitorRequestMetricIssue{}
+	out.Name = data.Name.Get()
+	out.ProjectId = data.Project.Get()
+	out.DataSources = []apiclient.ProjectMonitorDataSourceSnubaQuerySubscription{outDs}
+	out.ConditionGroup = apiclient.ProjectMonitorConditionGroup{
+		LogicType:  apiclient.ProjectMonitorConditionGroupLogicType(inConditionGroup.LogicType.Get()),
+		Conditions: outConditions,
 	}
+	out.Config = &outConfig
 
 	if data.Enabled.IsKnown() {
 		out.Enabled.Set(data.Enabled.Get())
@@ -134,12 +137,11 @@ func (r *MetricMonitorResource) getCreateJSONRequestBody(ctx context.Context, da
 			return nil, diags
 		}
 
-		switch {
-		case owner.TeamId.IsKnown():
+		if owner.TeamId.IsKnown() {
 			out.Owner.Set(fmt.Sprintf("team:%s", owner.TeamId.Get()))
-		case owner.UserId.IsKnown():
+		} else if owner.UserId.IsKnown() {
 			out.Owner.Set(fmt.Sprintf("user:%s", owner.UserId.Get()))
-		default:
+		} else {
 			out.Owner.SetNull()
 		}
 	} else {

--- a/internal/provider/resource_metric_monitor_test.go
+++ b/internal/provider/resource_metric_monitor_test.go
@@ -249,6 +249,85 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 					checks,
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName+"-updated")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("aggregate"), knownvalue.StringExact("count()")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("dataset"), knownvalue.StringExact("events")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("event_types"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("default"),
+						knownvalue.StringExact("error"),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(0)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"logic_type": knownvalue.StringExact("any"),
+						"conditions": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("gt"),
+								"comparison":       knownvalue.Float64Exact(100),
+								"condition_result": knownvalue.Int64Exact(75),
+							}),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("lte"),
+								"comparison":       knownvalue.Float64Exact(50),
+								"condition_result": knownvalue.Int64Exact(0),
+							}),
+						}),
+					})),
+				),
+			},
+			{
+				Config: testAccMetricMonitorResourceConfig(projectName, monitorName+"-updated", `
+					aggregate = "count()"
+					dataset = "events"
+					event_types = ["default", "error"]
+
+					condition_group = {
+						conditions = [
+							{
+								type = "gt"
+								comparison = 1.0
+								condition_result = 75
+							},
+							{
+								type = "lte"
+								comparison = 0.5
+								condition_result = 0
+							},
+						]
+					}
+
+					issue_detection = {
+						type = "static"
+					}
+				`),
+				ConfigStateChecks: append(
+					checks,
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName+"-updated")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("aggregate"), knownvalue.StringExact("count()")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("dataset"), knownvalue.StringExact("events")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("event_types"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("default"),
+						knownvalue.StringExact("error"),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(0)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"logic_type": knownvalue.StringExact("any"),
+						"conditions": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("gt"),
+								"comparison":       knownvalue.Float64Exact(1.0),
+								"condition_result": knownvalue.Int64Exact(75),
+							}),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("lte"),
+								"comparison":       knownvalue.Float64Exact(0.5),
+								"condition_result": knownvalue.Int64Exact(0),
+							}),
+						}),
+					})),
 				),
 			},
 			{
@@ -282,6 +361,30 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 					checks,
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("enabled"), knownvalue.Bool(false)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName+"-updated")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("aggregate"), knownvalue.StringExact("count()")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("dataset"), knownvalue.StringExact("events")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("event_types"), knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.StringExact("default"),
+						knownvalue.StringExact("error"),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(0)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"logic_type": knownvalue.StringExact("any"),
+						"conditions": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("gt"),
+								"comparison":       knownvalue.Float64Exact(100),
+								"condition_result": knownvalue.Int64Exact(75),
+							}),
+							knownvalue.ObjectPartial(map[string]knownvalue.Check{
+								"type":             knownvalue.StringExact("lte"),
+								"comparison":       knownvalue.Float64Exact(50),
+								"condition_result": knownvalue.Int64Exact(0),
+							}),
+						}),
+					})),
 				),
 			},
 			{

--- a/internal/provider/resource_uptime_monitor_impl.go
+++ b/internal/provider/resource_uptime_monitor_impl.go
@@ -81,12 +81,11 @@ func (r *UptimeMonitorResource) getCreateJSONRequestBody(ctx context.Context, da
 			return nil, diags
 		}
 
-		switch {
-		case owner.TeamId.IsKnown():
+		if owner.TeamId.IsKnown() {
 			out.Owner.Set(fmt.Sprintf("team:%s", owner.TeamId.Get()))
-		case owner.UserId.IsKnown():
+		} else if owner.UserId.IsKnown() {
 			out.Owner.Set(fmt.Sprintf("user:%s", owner.UserId.Get()))
-		default:
+		} else {
 			out.Owner.SetNull()
 		}
 	} else {


### PR DESCRIPTION
Fix truncation of float threshold values (e.g., 0.1, 0.25 for CLS metrics) in `sentry_metric_monitor` resource.

Changed `comparison` field type from `integer` to `number` in OpenAPI spec.

Fixes #875