### PR TITLE
fix(sentry_metric_monitor): update failing with "Invalid dataset for this query type

### DIFF
--- a/internal/provider/data_source_metric_monitor_impl.go
+++ b/internal/provider/data_source_metric_monitor_impl.go
@@ -107,8 +107,7 @@ func (m *MetricMonitorDataSourceModel) fill(ctx context.Context, data apiclient.
 	if v, err := dataSource.QueryObj.SnubaQuery.QueryType.Get(); err == nil {
 		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[v])
 	} else {
-		// BUG?
-		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[0])
+		m.QueryType.SetNull()
 	}
 	if v, err := dataSource.QueryObj.SnubaQuery.TimeWindow.Get(); err == nil {
 		m.TimeWindowSeconds.Set(v)

--- a/internal/provider/resource_metric_monitor_impl.go
+++ b/internal/provider/resource_metric_monitor_impl.go
@@ -271,14 +271,10 @@ func (m *MetricMonitorResourceModel) Fill(ctx context.Context, data apiclient.Pr
 	}
 	if v, err := dataSource.QueryObj.SnubaQuery.QueryType.Get(); err == nil {
 		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[v])
-	} else {
-		// BUG?
-		if m.QueryType.IsKnown() {
-			m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[0])
-		} else {
-			m.QueryType.SetNull()
-		}
 	}
+	// If API returns null for queryType, preserve the existing state value.
+	// Do not override with a hardcoded default as different datasets require different query types.
+
 	if v, err := dataSource.QueryObj.SnubaQuery.TimeWindow.Get(); err == nil {
 		m.TimeWindowSeconds.Set(v)
 	} else {

--- a/internal/provider/resource_metric_monitor_test.go
+++ b/internal/provider/resource_metric_monitor_test.go
@@ -573,6 +573,99 @@ func TestAccMetricMonitorResource_fractionalComparison(t *testing.T) {
 	})
 }
 
+func TestAccMetricMonitorResource_eventsAnalyticsPlatform(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("tf-project")
+	monitorName := acctest.RandomWithPrefix("tf-metric-monitor")
+	rn := "sentry_metric_monitor.test"
+
+	checks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("organization"), knownvalue.StringExact(acctest.TestOrganization)),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("project"), knownvalue.NotNull()),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("dataset"), knownvalue.StringExact("events_analytics_platform")),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("event_types"), knownvalue.SetExact([]knownvalue.Check{
+			knownvalue.StringExact("trace_item_span"),
+		})),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetricMonitorResourceConfig(projectName, monitorName, `
+					aggregate = "p75(measurements.lcp)"
+					dataset = "events_analytics_platform"
+					event_types = ["trace_item_span"]
+					time_window_seconds = 3600
+
+					condition_group = {
+						conditions = [
+							{
+								type = "gt"
+								comparison = 2500
+								condition_result = 75
+							},
+							{
+								type = "lte"
+								comparison = 2250
+								condition_result = 0
+							},
+						]
+					}
+
+					issue_detection = {
+						type = "static"
+					}
+				`),
+				ConfigStateChecks: append(
+					checks,
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("aggregate"), knownvalue.StringExact("p75(measurements.lcp)")),
+				),
+			},
+			{
+				Config: testAccMetricMonitorResourceConfig(projectName, monitorName+"-updated", `
+					aggregate = "p75(measurements.lcp)"
+					dataset = "events_analytics_platform"
+					event_types = ["trace_item_span"]
+					time_window_seconds = 3600
+
+					condition_group = {
+						conditions = [
+							{
+								type = "gt"
+								comparison = 2500
+								condition_result = 75
+							},
+							{
+								type = "lte"
+								comparison = 2250
+								condition_result = 0
+							},
+						]
+					}
+
+					issue_detection = {
+						type = "static"
+					}
+				`),
+				ConfigStateChecks: append(
+					checks,
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName+"-updated")),
+				),
+			},
+			{
+				ResourceName:            rn,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"query_type"},
+			},
+		},
+	})
+}
+
 func testAccMetricMonitorResourceConfig(projectName, name, extras string) string {
 	return fmt.Sprintf(`
 		resource "sentry_project" "test" {


### PR DESCRIPTION
Fix metric monitor update failing with "Invalid dataset for this query type"

When API returns null for `queryType`, the provider no longer overrides it with hardcoded `"error"` (id=0). This was causing updates to fail for monitors using `events_analytics_platform` dataset, which requires `queryType=1` (performance).

Fixes #876