### PR TITLE
fix: preserve query_type value when API returns null

### DIFF
--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -2778,7 +2778,6 @@ components:
         - environment
         - eventTypes
         - query
-        - queryType
         - timeWindow
         - extrapolationMode
       properties:

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -2435,7 +2435,7 @@ type ProjectMonitorDataSourceSnubaQuerySubscription struct {
 	EventTypes        []string                  `json:"eventTypes"`
 	ExtrapolationMode nullable.Nullable[string] `json:"extrapolationMode"`
 	Query             nullable.Nullable[string] `json:"query"`
-	QueryType         nullable.Nullable[int64]  `json:"queryType"`
+	QueryType         nullable.Nullable[int64]  `json:"queryType,omitempty"`
 	TimeWindow        nullable.Nullable[int64]  `json:"timeWindow"`
 }
 

--- a/internal/provider/data_source_metric_monitor_impl.go
+++ b/internal/provider/data_source_metric_monitor_impl.go
@@ -107,8 +107,7 @@ func (m *MetricMonitorDataSourceModel) fill(ctx context.Context, data apiclient.
 	if v, err := dataSource.QueryObj.SnubaQuery.QueryType.Get(); err == nil {
 		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[v])
 	} else {
-		// BUG?
-		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[0])
+		m.QueryType.SetNull()
 	}
 	if v, err := dataSource.QueryObj.SnubaQuery.TimeWindow.Get(); err == nil {
 		m.TimeWindowSeconds.Set(v)

--- a/internal/provider/data_source_metric_monitor_test.go
+++ b/internal/provider/data_source_metric_monitor_test.go
@@ -68,7 +68,7 @@ func TestAccMetricMonitorDataSource_threshold(t *testing.T) {
 						knownvalue.StringExact("error"),
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.StringExact("is:unresolved")),
-					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(3600)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"logic_type": knownvalue.StringExact("any"),
@@ -129,7 +129,7 @@ func TestAccMetricMonitorDataSource_threshold(t *testing.T) {
 						knownvalue.StringExact("error"),
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.StringExact("is:unresolved")),
-					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(3600)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"logic_type": knownvalue.StringExact("any"),
@@ -270,7 +270,7 @@ func TestAccMetricMonitorDataSource_dynamic(t *testing.T) {
 						knownvalue.StringExact("error"),
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.StringExact("is:unresolved")),
-					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(3600)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"logic_type": knownvalue.StringExact("any"),

--- a/internal/provider/resource_metric_monitor_gen.go
+++ b/internal/provider/resource_metric_monitor_gen.go
@@ -145,6 +145,9 @@ func (r *MetricMonitorResource) Schema(ctx context.Context, req resource.SchemaR
 					Optional:            true,
 					Computed:            true,
 					CustomType:          supertypes.StringType{},
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.UseStateForUnknown(),
+					},
 				},
 				sentrydata.SnubaQueryTypes,
 			),

--- a/internal/provider/resource_metric_monitor_impl.go
+++ b/internal/provider/resource_metric_monitor_impl.go
@@ -273,14 +273,10 @@ func (m *MetricMonitorResourceModel) Fill(ctx context.Context, data apiclient.Pr
 	}
 	if v, err := dataSource.QueryObj.SnubaQuery.QueryType.Get(); err == nil {
 		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[v])
-	} else {
-		// BUG?
-		if m.QueryType.IsKnown() {
-			m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[0])
-		} else {
-			m.QueryType.SetNull()
-		}
 	}
+	// If API returns null for queryType, preserve the existing state value.
+	// Do not override with a hardcoded default as different datasets require different query types.
+
 	if v, err := dataSource.QueryObj.SnubaQuery.TimeWindow.Get(); err == nil {
 		m.TimeWindowSeconds.Set(v)
 	} else {

--- a/internal/provider/resource_metric_monitor_impl.go
+++ b/internal/provider/resource_metric_monitor_impl.go
@@ -271,8 +271,11 @@ func (m *MetricMonitorResourceModel) Fill(ctx context.Context, data apiclient.Pr
 	} else {
 		m.Query.SetNull()
 	}
+
 	if v, err := dataSource.QueryObj.SnubaQuery.QueryType.Get(); err == nil {
 		m.QueryType.Set(sentrydata.SnubaQueryTypeIdToName[v])
+	} else if m.QueryType.IsUnknown() {
+		m.QueryType.SetNull()
 	}
 	// If API returns null for queryType, preserve the existing state value.
 	// Do not override with a hardcoded default as different datasets require different query types.

--- a/internal/provider/resource_metric_monitor_test.go
+++ b/internal/provider/resource_metric_monitor_test.go
@@ -256,7 +256,7 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 						knownvalue.StringExact("error"),
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.Null()),
-					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(0)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"logic_type": knownvalue.StringExact("any"),
@@ -311,7 +311,7 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 						knownvalue.StringExact("error"),
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.Null()),
-					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(0)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"logic_type": knownvalue.StringExact("any"),
@@ -368,7 +368,7 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 						knownvalue.StringExact("error"),
 					})),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query"), knownvalue.Null()),
-					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("query_type"), knownvalue.StringExact("error")),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("time_window_seconds"), knownvalue.Int64Exact(0)),
 					statecheck.ExpectKnownValue(rn, tfjsonpath.New("condition_group"), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"logic_type": knownvalue.StringExact("any"),
@@ -388,10 +388,11 @@ func TestAccMetricMonitorResource_threshold(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      rn,
-				ImportState:       true,
-				ImportStateIdFunc: acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
-				ImportStateVerify: true,
+				ResourceName:            rn,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"query_type"},
 			},
 		},
 	})

--- a/internal/provider/resource_metric_monitor_test.go
+++ b/internal/provider/resource_metric_monitor_test.go
@@ -676,6 +676,99 @@ func TestAccMetricMonitorResource_fractionalComparison(t *testing.T) {
 	})
 }
 
+func TestAccMetricMonitorResource_eventsAnalyticsPlatform(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("tf-project")
+	monitorName := acctest.RandomWithPrefix("tf-metric-monitor")
+	rn := "sentry_metric_monitor.test"
+
+	checks := []statecheck.StateCheck{
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("id"), knownvalue.NotNull()),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("organization"), knownvalue.StringExact(acctest.TestOrganization)),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("project"), knownvalue.NotNull()),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("dataset"), knownvalue.StringExact("events_analytics_platform")),
+		statecheck.ExpectKnownValue(rn, tfjsonpath.New("event_types"), knownvalue.SetExact([]knownvalue.Check{
+			knownvalue.StringExact("trace_item_span"),
+		})),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMetricMonitorResourceConfig(projectName, monitorName, `
+					aggregate = "p75(measurements.lcp)"
+					dataset = "events_analytics_platform"
+					event_types = ["trace_item_span"]
+					time_window_seconds = 3600
+
+					condition_group = {
+						conditions = [
+							{
+								type = "gt"
+								comparison = 2500
+								condition_result = 75
+							},
+							{
+								type = "lte"
+								comparison = 2250
+								condition_result = 0
+							},
+						]
+					}
+
+					issue_detection = {
+						type = "static"
+					}
+				`),
+				ConfigStateChecks: append(
+					checks,
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName)),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("aggregate"), knownvalue.StringExact("p75(measurements.lcp)")),
+				),
+			},
+			{
+				Config: testAccMetricMonitorResourceConfig(projectName, monitorName+"-updated", `
+					aggregate = "p75(measurements.lcp)"
+					dataset = "events_analytics_platform"
+					event_types = ["trace_item_span"]
+					time_window_seconds = 3600
+
+					condition_group = {
+						conditions = [
+							{
+								type = "gt"
+								comparison = 2500
+								condition_result = 75
+							},
+							{
+								type = "lte"
+								comparison = 2250
+								condition_result = 0
+							},
+						]
+					}
+
+					issue_detection = {
+						type = "static"
+					}
+				`),
+				ConfigStateChecks: append(
+					checks,
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("name"), knownvalue.StringExact(monitorName+"-updated")),
+				),
+			},
+			{
+				ResourceName:            rn,
+				ImportState:             true,
+				ImportStateIdFunc:       acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"query_type"},
+			},
+		},
+	})
+}
+
 func testAccMetricMonitorResourceConfig(projectName, name, extras string) string {
 	return fmt.Sprintf(`
 		resource "sentry_project" "test" {

--- a/internal/providergen/resources/metric_monitor.ts
+++ b/internal/providergen/resources/metric_monitor.ts
@@ -139,6 +139,7 @@ export default {
         "The type of query. If no value is provided, `query_type` is set to the default for the specified `dataset.`",
       computedOptionalRequired: "computed_optional",
       enum: "sentrydata.SnubaQueryTypes",
+      planModifiers: ["stringplanmodifier.UseStateForUnknown()"],
     },
     {
       name: "time_window_seconds",


### PR DESCRIPTION
Remove hardcoded fallback to 'error' query_type when API returns null.
This fixes updates failing with 'Invalid dataset for this query type'
error for monitors using events_analytics_platform dataset.

Fixes #876