### PR TITLE
fix(sentry_issue_alert): populate rule body on import

### DIFF
--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -1085,6 +1085,22 @@ func (r *IssueAlertResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 func (r *IssueAlertResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	tfutils.ImportStateThreePartId(ctx, "organization", "project", req, resp)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// terraform import only provides the resource ID, never the configuration. Fill
+	// (used by the subsequent Read) only refreshes the conditions/filters/actions
+	// representation that is already present in state: it populates the legacy JSON
+	// attributes when they are non-null, or the typed *_v2 lists when those are
+	// non-null, and otherwise leaves the rule body untouched. After a bare import all
+	// of those attributes are null, so the rule body would never be read back into
+	// state, producing perpetual drift (and a doomed update that targets a rule the
+	// plan thinks must change). Seed the typed (*_v2) lists -- the non-deprecated
+	// representation -- so Read populates the rule body from the API.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("conditions_v2"), supertypes.NewListNestedObjectValueOfValueSlice(ctx, []IssueAlertConditionModel{}))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("filters_v2"), supertypes.NewListNestedObjectValueOfValueSlice(ctx, []IssueAlertFilterModel{}))...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("actions_v2"), supertypes.NewListNestedObjectValueOfValueSlice(ctx, []IssueAlertActionModel{}))...)
 }
 
 func (r *IssueAlertResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {

--- a/internal/provider/resource_issue_alert_test.go
+++ b/internal/provider/resource_issue_alert_test.go
@@ -664,6 +664,88 @@ func TestAccIssueAlertResource_basic(t *testing.T) {
 	})
 }
 
+// TestAccIssueAlertResource_importRoundTrip reproduces the adoption flow for a
+// classic issue-alert rule: import an existing rule and confirm the rule body is
+// read back into state (no follow-up drift), then update it without a 404.
+//
+// Before the import fix, ImportState only populated organization/project/id, so the
+// conditions_v2/filters_v2/actions_v2 lists stayed null. The import step below uses
+// ImportStateVerify, which compares the imported state to the applied state and would
+// fail because the rule body was missing -- the same null body that forced a doomed
+// "update" on the next apply.
+func TestAccIssueAlertResource_importRoundTrip(t *testing.T) {
+	rn := "sentry_issue_alert.test"
+	team := acctest.RandomWithPrefix("tf-team")
+	project := acctest.RandomWithPrefix("tf-project")
+	alert := acctest.RandomWithPrefix("tf-issue-alert")
+
+	conditionsCheck := statecheck.ExpectKnownValue(rn, tfjsonpath.New("conditions_v2"), knownvalue.ListExact([]knownvalue.Check{
+		knownvalue.ObjectPartial(map[string]knownvalue.Check{"first_seen_event": knownvalue.NotNull()}),
+		knownvalue.ObjectPartial(map[string]knownvalue.Check{"reappeared_event": knownvalue.NotNull()}),
+		knownvalue.ObjectPartial(map[string]knownvalue.Check{"regression_event": knownvalue.NotNull()}),
+	}))
+	taggedCheck := func(value string) statecheck.StateCheck {
+		return statecheck.ExpectKnownValue(rn, tfjsonpath.New("filters_v2"), knownvalue.ListExact([]knownvalue.Check{
+			knownvalue.ObjectPartial(map[string]knownvalue.Check{
+				"tagged_event": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+					"key":   knownvalue.StringExact("monitor"),
+					"match": knownvalue.StringExact("EQUAL"),
+					"value": knownvalue.StringExact(value),
+				}),
+			}),
+		}))
+	}
+	actionsCheck := statecheck.ExpectKnownValue(rn, tfjsonpath.New("actions_v2"), knownvalue.ListExact([]knownvalue.Check{
+		knownvalue.ObjectPartial(map[string]knownvalue.Check{
+			"notify_email": knownvalue.ObjectPartial(map[string]knownvalue.Check{
+				"target_type":      knownvalue.StringExact("IssueOwners"),
+				"fallthrough_type": knownvalue.StringExact("ActiveMembers"),
+			}),
+		}),
+	}))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckIssueAlertDestroy,
+		Steps: []resource.TestStep{
+			// Create the classic issue-alert rule.
+			{
+				Config: testAccIssueAlertConfig_importRoundTrip(team, project, alert, "server-health", 0),
+				ConfigStateChecks: []statecheck.StateCheck{
+					conditionsCheck,
+					taggedCheck("server-health"),
+					actionsCheck,
+				},
+			},
+			// Import must round-trip the full rule body. ImportStateVerify fails if the
+			// imported state differs from the applied state (i.e. if the body is null).
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
+			},
+			// Updating the (now in-state) rule must not 404.
+			{
+				Config: testAccIssueAlertConfig_importRoundTrip(team, project, alert, "db-health", 5),
+				ConfigStateChecks: []statecheck.StateCheck{
+					conditionsCheck,
+					taggedCheck("db-health"),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("frequency"), knownvalue.Int64Exact(5)),
+				},
+			},
+			// Re-import after the update to confirm the round-trip still holds.
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: acctest.ThreePartImportStateIdFunc(rn, "organization", "project"),
+			},
+		},
+	})
+}
+
 func TestAccIssueAlertResource_emptyArray(t *testing.T) {
 	rn := "sentry_issue_alert.test"
 	team := acctest.RandomWithPrefix("tf-team")
@@ -1199,6 +1281,47 @@ resource "sentry_issue_alert" "test" {
 	%[4]s
 }
 `, team, project, alert, extras)
+}
+
+func testAccIssueAlertConfig_importRoundTrip(team string, project string, alert string, taggedValue string, frequency int) string {
+	return testAccOrganizationDataSourceConfig + fmt.Sprintf(`
+resource "sentry_team" "test" {
+	organization = data.sentry_organization.test.slug
+	name         = "%[1]s"
+	slug         = "%[1]s"
+}
+
+resource "sentry_project" "test" {
+	organization = sentry_team.test.organization
+	teams        = [sentry_team.test.slug]
+	name         = "%[2]s"
+	platform     = "go"
+}
+
+resource "sentry_issue_alert" "test" {
+	organization = sentry_project.test.organization
+	project      = sentry_project.test.id
+	name         = "%[3]s"
+
+	action_match = "any"
+	filter_match = "all"
+	frequency    = %[5]d
+
+	conditions_v2 = [
+		{ first_seen_event = {} },
+		{ reappeared_event = {} },
+		{ regression_event = {} },
+	]
+
+	filters_v2 = [
+		{ tagged_event = { key = "monitor", match = "EQUAL", value = "%[4]s" } },
+	]
+
+	actions_v2 = [
+		{ notify_email = { target_type = "IssueOwners", fallthrough_type = "ActiveMembers" } },
+	]
+}
+`, team, project, alert, taggedValue, frequency)
 }
 
 func testAccIssueAlertConfig_jsonValues(team string, project string, alert string) string {


### PR DESCRIPTION
Fixes #887. Related: #793.

## Problem

Importing an existing classic issue-alert rule does not read the rule body back
into state. `IssueAlertModel.Fill` (used by `Read`) only refreshes whichever body
representation is already non-null in state — the legacy `conditions`/`filters`/
`actions` JSON strings, or the typed `conditions_v2`/`filters_v2`/`actions_v2`
lists. `ImportState` only set `organization`/`project`/`id`, so after a bare import
every body attribute was null and `Fill` wrote nothing back.

The result was perpetual drift (the body always showed as a pending change, as in
#793) and a doomed first `apply`, which force-updated the rule and failed with
`Not found — No matching issue alert found`.

## Fix

Seed the typed `*_v2` lists (empty, non-null) in `ImportState`, which makes the
subsequent `Read` populate the rule body from the GET response. The `*_v2` lists are
the non-deprecated representation, so imports now land on the recommended form.
Legacy JSON-string attributes remain null after import.

## Test

Adds `TestAccIssueAlertResource_importRoundTrip`, which:

1. creates a classic rule (3 conditions, a `tagged_event` filter, a `notify_email`
   action),
2. imports it with `ImportStateVerify: true` — this fails on `main` because the
   imported state is missing the rule body, and passes with this change,
3. updates the rule (proving the update path no longer 404s), and
4. re-imports to confirm the round-trip still holds.

The existing import steps in other `sentry_issue_alert` acceptance tests are
unaffected (they assert importability without `ImportStateVerify`).

## Notes

- No schema change, so generated docs are unchanged.
- `terraform import` has no access to configuration, so it cannot know whether the
  user intends the legacy or `*_v2` representation; imports default to `*_v2`
  (the non-deprecated form).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
