### PR TITLE
docs(issue_alert): document migration to sentry_alert

### DIFF
--- a/docs/resources/issue_alert.md
+++ b/docs/resources/issue_alert.md
@@ -3,17 +3,32 @@
 page_title: "sentry_issue_alert Resource - terraform-provider-sentry"
 subcategory: ""
 description: |-
-  ⚠️ This resource is deprecated. Please migrate to sentry_alert alert.md resource instead.
+  ⚠️ This resource is deprecated in favor of sentry_alert alert.md.
   Create an Issue Alert Rule for a Project. See the Sentry Documentation https://docs.sentry.io/api/alerts/create-an-issue-alert-rule-for-a-project/ for more information.
+  Migrating to sentry_alert
+  A classic issue alert maps onto sentry_alert alert.md as follows:
+  Issue-state conditions (first_seen_event, regression_event, reappeared_event) become trigger_conditions. Frequency conditions (e.g. event_frequency) move to action_filters[].conditions (e.g. event_frequency_count).filters become action_filters[].conditions (e.g. tagged_event, age_comparison, level), and filter_match becomes action_filters[].logic_type.actions become action_filters[].actions (e.g. email, slack), and frequency becomes frequency_minutes.sentry_alert requires monitor_ids. For a classic alert that is not tied to a monitor, reference a project default monitor with the sentry_project_error_monitor ../data-sources/project_error_monitor.md or sentry_project_issue_stream_monitor ../data-sources/project_issue_stream_monitor.md data source — no monitor resource needs to be created.
+  A few legacy trigger types (e.g. new_high_priority_issue, existing_high_priority_issue) are currently only available through sentry_alert's legacy_trigger_conditions passthrough.
   NOTE: The conditions, filters, and actions attributes, which are JSON strings, have been deprecated in favor of conditions_v2, filters_v2, and actions_v2, which are lists of objects.
   The *_v2 attributes are available starting from v0.14.2.
 ---
 
 # sentry_issue_alert (Resource)
 
-⚠️ This resource is deprecated. Please migrate to [`sentry_alert`](alert.md) resource instead.
+⚠️ This resource is deprecated in favor of [`sentry_alert`](alert.md).
 
 Create an Issue Alert Rule for a Project. See the [Sentry Documentation](https://docs.sentry.io/api/alerts/create-an-issue-alert-rule-for-a-project/) for more information.
+
+### Migrating to `sentry_alert`
+
+A classic issue alert maps onto [`sentry_alert`](alert.md) as follows:
+
+- Issue-state `conditions` (`first_seen_event`, `regression_event`, `reappeared_event`) become `trigger_conditions`. Frequency conditions (e.g. `event_frequency`) move to `action_filters[].conditions` (e.g. `event_frequency_count`).
+- `filters` become `action_filters[].conditions` (e.g. `tagged_event`, `age_comparison`, `level`), and `filter_match` becomes `action_filters[].logic_type`.
+- `actions` become `action_filters[].actions` (e.g. `email`, `slack`), and `frequency` becomes `frequency_minutes`.
+- `sentry_alert` requires `monitor_ids`. For a classic alert that is not tied to a monitor, reference a project default monitor with the [`sentry_project_error_monitor`](../data-sources/project_error_monitor.md) or [`sentry_project_issue_stream_monitor`](../data-sources/project_issue_stream_monitor.md) data source — no monitor resource needs to be created.
+
+A few legacy trigger types (e.g. `new_high_priority_issue`, `existing_high_priority_issue`) are currently only available through `sentry_alert`'s `legacy_trigger_conditions` passthrough.
 
 **NOTE:** The `conditions`, `filters`, and `actions` attributes, which are JSON strings, have been deprecated in favor of `conditions_v2`, `filters_v2`, and `actions_v2`, which are lists of objects.
 

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -61,10 +61,17 @@ func (r *IssueAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 	}, []string{"5m", "15m", "1h", "1d", "1w", "30d"})
 
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "⚠️ This resource is deprecated. Please migrate to [`sentry_alert`](alert.md) resource instead.\n\nCreate an Issue Alert Rule for a Project. See the [Sentry Documentation](https://docs.sentry.io/api/alerts/create-an-issue-alert-rule-for-a-project/) for more information.\n\n" +
+		MarkdownDescription: "⚠️ This resource is deprecated in favor of [`sentry_alert`](alert.md).\n\nCreate an Issue Alert Rule for a Project. See the [Sentry Documentation](https://docs.sentry.io/api/alerts/create-an-issue-alert-rule-for-a-project/) for more information.\n\n" +
+			"### Migrating to `sentry_alert`\n\n" +
+			"A classic issue alert maps onto [`sentry_alert`](alert.md) as follows:\n\n" +
+			"- Issue-state `conditions` (`first_seen_event`, `regression_event`, `reappeared_event`) become `trigger_conditions`. Frequency conditions (e.g. `event_frequency`) move to `action_filters[].conditions` (e.g. `event_frequency_count`).\n" +
+			"- `filters` become `action_filters[].conditions` (e.g. `tagged_event`, `age_comparison`, `level`), and `filter_match` becomes `action_filters[].logic_type`.\n" +
+			"- `actions` become `action_filters[].actions` (e.g. `email`, `slack`), and `frequency` becomes `frequency_minutes`.\n" +
+			"- `sentry_alert` requires `monitor_ids`. For a classic alert that is not tied to a monitor, reference a project default monitor with the [`sentry_project_error_monitor`](../data-sources/project_error_monitor.md) or [`sentry_project_issue_stream_monitor`](../data-sources/project_issue_stream_monitor.md) data source — no monitor resource needs to be created.\n\n" +
+			"A few legacy trigger types (e.g. `new_high_priority_issue`, `existing_high_priority_issue`) are currently only available through `sentry_alert`'s `legacy_trigger_conditions` passthrough.\n\n" +
 			"**NOTE:** The `conditions`, `filters`, and `actions` attributes, which are JSON strings, have been deprecated in favor of `conditions_v2`, `filters_v2`, and `actions_v2`, which are lists of objects.\n\n" +
 			"The `*_v2` attributes are available starting from v0.14.2.",
-		DeprecationMessage: "This resource is deprecated. Please migrate to `sentry_alert` resource instead.",
+		DeprecationMessage: "This resource is deprecated in favor of `sentry_alert`. See the sentry_issue_alert resource documentation for a migration guide (note: `monitor_ids` can reference a project default monitor via the sentry_project_error_monitor / sentry_project_issue_stream_monitor data sources).",
 
 		Version: 2,
 


### PR DESCRIPTION
## Problem

`sentry_issue_alert` is deprecated in favor of `sentry_alert`, but the notice
doesn't explain how a classic issue alert maps onto the new resource, and the
required `monitor_ids` field makes migration look impossible. This is the
confusion reported in #845.

In practice `sentry_alert` can express most classic issue alerts — the rule
body is restructured, not dropped:

- Issue-state `conditions` (`first_seen_event`, `regression_event`,
  `reappeared_event`) → `trigger_conditions`. Frequency conditions (e.g.
  `event_frequency`) → `action_filters[].conditions` (e.g. `event_frequency_count`).
- `filters` → `action_filters[].conditions`; `filter_match` → `action_filters[].logic_type`.
- `actions` → `action_filters[].actions`; `frequency` → `frequency_minutes`.
- `monitor_ids` does not require creating a monitor: a classic error/issue alert
  can reference a project default monitor via the `sentry_project_error_monitor`
  or `sentry_project_issue_stream_monitor` data sources.

A few legacy trigger types (e.g. `new_high_priority_issue`,
`existing_high_priority_issue`) remain only available through
`legacy_trigger_conditions`.

## Change

- Add a "Migrating to `sentry_alert`" section to the `sentry_issue_alert`
  resource description, and regenerate `docs/resources/issue_alert.md` via
  `tfplugindocs`.
- Update the plan-time `DeprecationMessage` to point at the migration guide and
  mention the `monitor_ids` default-monitor data sources.

Docs only — no schema or behavior change. `go build`, `gofmt`, and
`tfplugindocs` are clean.

Refs #845

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
