### PR TITLE
fix(issue_alert): echo notify_email fallthrough_type for all target types

### DIFF
--- a/internal/provider/model_issue_alert.go
+++ b/internal/provider/model_issue_alert.go
@@ -788,12 +788,13 @@ func (m *IssueAlertActionNotifyEmailModel) Fill(ctx context.Context, action apic
 		m.TargetIdentifier = types.StringValue(v.String())
 	}
 
-	// Only set FallthroughType for IssueOwners
-	if action.TargetType == "IssueOwners" {
-		m.FallthroughType = types.StringPointerValue(action.FallthroughType)
-	} else {
-		m.FallthroughType = types.StringNull()
-	}
+	// Echo FallthroughType back regardless of TargetType. The API now reliably
+	// returns a fallthroughType for email actions (defaulting to ActiveMembers),
+	// so previously gating this on TargetType == "IssueOwners" nulled out a value
+	// the user had configured for Team/Member targets, causing perpetual drift on
+	// fallthrough_type and breaking the actions_v2 reorder (the field is part of
+	// the reorder key). See getsentry/sentry#118404.
+	m.FallthroughType = types.StringPointerValue(action.FallthroughType)
 
 	return
 }

--- a/internal/provider/resource_issue_alert.go
+++ b/internal/provider/resource_issue_alert.go
@@ -372,6 +372,13 @@ func (r *IssueAlertResource) Schema(ctx context.Context, req resource.SchemaRequ
 								"fallthrough_type": tfutils.WithEnumStringAttribute(schema.StringAttribute{
 									MarkdownDescription: "Who the notification should be sent to if there are no suggested assignees.",
 									Optional:            true,
+									// Computed because the API defaults a fallthroughType
+									// (ActiveMembers) for email actions even when one is not
+									// supplied — and for every target_type, not just
+									// IssueOwners (see getsentry/sentry#118404). Without this,
+									// omitting fallthrough_type plans null but the API returns
+									// a value, producing "inconsistent result after apply".
+									Computed: true,
 								}, []string{"AllMembers", "ActiveMembers", "NoOne"}),
 							},
 						},

--- a/internal/provider/resource_issue_alert_test.go
+++ b/internal/provider/resource_issue_alert_test.go
@@ -500,7 +500,10 @@ func TestAccIssueAlertResource_basic(t *testing.T) {
 								"name":              knownvalue.NotNull(),
 								"target_type":       knownvalue.StringExact("Team"),
 								"target_identifier": knownvalue.NotNull(),
-								"fallthrough_type":  knownvalue.Null(),
+								// The API defaults fallthroughType to ActiveMembers for
+								// all email actions, not just IssueOwners. See
+								// getsentry/sentry#118404.
+								"fallthrough_type": knownvalue.StringExact("ActiveMembers"),
 							}),
 						}),
 						knownvalue.ObjectPartial(map[string]knownvalue.Check{
@@ -1044,7 +1047,10 @@ func TestAccIssueAlertResource_forExpression(t *testing.T) {
 								"name":              knownvalue.NotNull(),
 								"target_type":       knownvalue.StringExact("Team"),
 								"target_identifier": knownvalue.NotNull(),
-								"fallthrough_type":  knownvalue.Null(),
+								// The API defaults fallthroughType to ActiveMembers for
+								// all email actions, not just IssueOwners. See
+								// getsentry/sentry#118404.
+								"fallthrough_type": knownvalue.StringExact("ActiveMembers"),
 							}),
 						}),
 					})),


### PR DESCRIPTION
## Problem

A `sentry_issue_alert` with a `notify_email` action whose `target_type` is `Team` or `Member` (and a `fallthrough_type` set) shows **perpetual plan drift** — `fallthrough_type` is repeatedly added back, and because `fallthrough_type` is part of the `actions_v2` reorder key, the whole `actions_v2`/`conditions_v2`/`filters_v2` list churns with `name -> (known after apply)`. Reported in #822 (follow-up).

Root cause: `IssueAlertActionNotifyEmailModel.Fill()` only kept `fallthrough_type` when `target_type == "IssueOwners"` and nulled it otherwise. So a configured value for Team/Member targets was discarded on read.

## Fix

1. **`Fill()` now echoes `fallthrough_type` back unconditionally**, matching the newer `sentry_alert` resource. This is safe because the Sentry API now reliably returns a `fallthroughType` for email actions of every target type (defaulting to `ActiveMembers`) — see getsentry/sentry#118404.
2. **`fallthrough_type` is now `Optional + Computed`.** The API defaults it even when omitted, so without `Computed` an omitted value plans `null` but applies `ActiveMembers`, producing `Error: Provider produced inconsistent result after apply`.

## Verification

Verified against the live Sentry API: a `Team`-target `notify_email` returns `fallthroughType=ActiveMembers` whether or not it is set in config. After both changes, apply succeeds and re-plan reports **no changes** for IssueOwners, Team-with-fallthrough, and Team-without-fallthrough.

`TestAccIssueAlertResource_forExpression` passes. The two `fallthrough_type` test assertions for Team targets were updated from `Null()` to `ActiveMembers` to reflect the API's actual default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)