### PR TITLE
fix(issue_alert): ignore leading "#" in slack_notify_service ordering key

### DIFF
--- a/internal/provider/model_issue_alert_ordering.go
+++ b/internal/provider/model_issue_alert_ordering.go
@@ -154,8 +154,15 @@ func issueAlertActionModelKey(ctx context.Context) func(m IssueAlertActionModel)
 				f.Account.ValueString(), f.Service.ValueString(), f.Severity.ValueString())
 		case m.SlackNotifyService.IsKnown():
 			f := m.SlackNotifyService.MustGet(ctx)
+			// Normalize the channel the same way sentrytypes.SlackChannel's
+			// StringSemanticEquals does (ignore a leading "#"). Sentry returns
+			// the channel without the "#", so keying on the raw value makes the
+			// prior (planned/state) and incoming (API) keys diverge, which
+			// prevents reorderToMatchPrior from pairing them and produces a
+			// "Provider produced inconsistent result after apply" error on
+			// actions_v2 ordering.
 			return fmt.Sprintf("slack_notify_service\x00%s\x00%s\x00%s",
-				f.Workspace.ValueString(), f.Channel.ValueString(), stringSetKey(f.Tags))
+				f.Workspace.ValueString(), strings.TrimPrefix(f.Channel.ValueString(), "#"), stringSetKey(f.Tags))
 		case m.MsTeamsNotifyService.IsKnown():
 			f := m.MsTeamsNotifyService.MustGet(ctx)
 			return fmt.Sprintf("msteams_notify_service\x00%s\x00%s",

--- a/internal/provider/resource_issue_alert_unit_test.go
+++ b/internal/provider/resource_issue_alert_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrytypes"
+	supertypes "github.com/orange-cloudavenue/terraform-plugin-framework-supertypes"
 )
 
 func TestIssueAlertConditionModel_ToApi_emptyElement(t *testing.T) {
@@ -197,6 +198,82 @@ func TestReorderToMatchPrior_handlesDuplicateTypes(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("index %d: got %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+// nullActionModel returns an IssueAlertActionModel with every action variant
+// set to null, so a caller can populate exactly one variant.
+func nullActionModel(ctx context.Context) IssueAlertActionModel {
+	return IssueAlertActionModel{
+		NotifyEmail:                  supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionNotifyEmailModel](ctx),
+		NotifyEvent:                  supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionNotifyEventModel](ctx),
+		NotifyEventService:           supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionNotifyEventServiceModel](ctx),
+		NotifyEventSentryApp:         supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionNotifyEventSentryAppModel](ctx),
+		OpsgenieNotifyTeam:           supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionOpsgenieNotifyTeam](ctx),
+		PagerDutyNotifyService:       supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionPagerDutyNotifyServiceModel](ctx),
+		SlackNotifyService:           supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionSlackNotifyServiceModel](ctx),
+		MsTeamsNotifyService:         supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionMsTeamsNotifyServiceModel](ctx),
+		DiscordNotifyService:         supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionDiscordNotifyServiceModel](ctx),
+		JiraCreateTicket:             supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionJiraCreateTicketModel](ctx),
+		JiraServerCreateTicket:       supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionJiraServerCreateTicketModel](ctx),
+		GitHubCreateTicket:           supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionGitHubCreateTicketModel](ctx),
+		GitHubEnterpriseCreateTicket: supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionGitHubEnterpriseCreateTicketModel](ctx),
+		AzureDevopsCreateTicket:      supertypes.NewSingleNestedObjectValueOfNull[IssueAlertActionAzureDevopsCreateTicketModel](ctx),
+	}
+}
+
+func slackAction(ctx context.Context, workspace, channel string) IssueAlertActionModel {
+	m := nullActionModel(ctx)
+	m.SlackNotifyService = supertypes.NewSingleNestedObjectValueOf(ctx, &IssueAlertActionSlackNotifyServiceModel{
+		Workspace: types.StringValue(workspace),
+		Channel:   sentrytypes.NewSlackChannelValue(channel),
+		ChannelId: types.StringValue("C123"),
+		Tags:      sentrytypes.StringSet{},
+	})
+	return m
+}
+
+// A slack_notify_service action key must ignore a leading "#" on the channel,
+// matching sentrytypes.SlackChannel's StringSemanticEquals. Sentry returns the
+// channel without the "#", so without this the prior and incoming keys diverge
+// and reorderToMatchPrior cannot pair them.
+func TestIssueAlertActionModelKey_slackChannelIgnoresHashPrefix(t *testing.T) {
+	ctx := context.Background()
+	key := issueAlertActionModelKey(ctx)
+
+	withHash := key(slackAction(ctx, "ws123", "#errors-prod"))
+	withoutHash := key(slackAction(ctx, "ws123", "errors-prod"))
+
+	if withHash != withoutHash {
+		t.Errorf("slack action key should ignore leading '#': %q != %q", withHash, withoutHash)
+	}
+}
+
+// End-to-end: when Sentry reorders actions AND returns channels without the
+// "#", reorderToMatchPrior must still restore the prior order.
+func TestReorderToMatchPrior_slackActionsWithNormalizedChannel(t *testing.T) {
+	ctx := context.Background()
+	keyFn := issueAlertActionModelKey(ctx)
+
+	prior := []IssueAlertActionModel{
+		slackAction(ctx, "A", "#errors-prod"),
+		slackAction(ctx, "B", "#errors-staging"),
+	}
+	// Sentry: reordered, and "#" stripped.
+	incoming := []IssueAlertActionModel{
+		slackAction(ctx, "B", "errors-staging"),
+		slackAction(ctx, "A", "errors-prod"),
+	}
+
+	got := reorderToMatchPrior(prior, incoming, keyFn)
+	if len(got) != 2 {
+		t.Fatalf("len mismatch: got %d, want 2", len(got))
+	}
+	if ws := got[0].SlackNotifyService.MustGet(ctx).Workspace.ValueString(); ws != "A" {
+		t.Errorf("index 0: got workspace %q, want A", ws)
+	}
+	if ws := got[1].SlackNotifyService.MustGet(ctx).Workspace.ValueString(); ws != "B" {
+		t.Errorf("index 1: got workspace %q, want B", ws)
 	}
 }
 


### PR DESCRIPTION
## Problem

A `sentry_issue_alert` whose `actions_v2` contains a `slack_notify_service` action **alongside another action** (e.g. `notify_email`) fails on **apply** — the plan is clean, but:

```
Error: Provider produced inconsistent result after apply
When applying changes to sentry_issue_alert.example, provider produced an
unexpected new value: .actions_v2[0].slack_notify_service: was
cty.ObjectVal({"channel":cty.StringVal("#errors-prod"), ...}), but now null.
```

## Root cause

`reorderToMatchPrior` stabilizes list order after reading from the API by pairing prior (planned/state) items with incoming (API) items via `issueAlertActionModelKey`. For `slack_notify_service`, that key uses the **raw** `channel`:

```go
f.Workspace.ValueString(), f.Channel.ValueString(), stringSetKey(f.Tags)
```

But Sentry returns the channel **without** the leading `#`, and `sentrytypes.SlackChannel.StringSemanticEquals` already treats `#errors-prod` and `errors-prod` as equal. So the prior key (`#errors-prod`) and the incoming key (`errors-prod`) **never match** → the slack action can't be paired → it's appended in the wrong position → the reordered result differs from the prior, tripping the consistency check.

This only surfaces when the list has ≥2 actions (single-action lists have no ordering to get wrong), which is why it shows up with `slack + notify_email`.

## Fix

Normalize the channel in the ordering key with the same `strings.TrimPrefix(_, "#")` the `SlackChannel` type uses for semantic equality, so prior/incoming keys match and `reorderToMatchPrior` preserves order.

One-line change in `issueAlertActionModelKey`, plus unit tests:
- `TestIssueAlertActionModelKey_slackChannelIgnoresHashPrefix` — the key ignores a leading `#`.
- `TestReorderToMatchPrior_slackActionsWithNormalizedChannel` — end-to-end: reordered + `#`-stripped API actions are restored to prior order.

## Testing

`go build`, `go vet`, and `gofmt` are clean, and the test binary compiles. I couldn't run the package's test suite locally because `TestMain` calls `acctest.SetupShared` (needs live Sentry API access), so I'm relying on CI to run the added unit tests — happy to adjust if they need tweaks.