### PR TITLE
fix: handle 404 in team_member Delete

### DIFF
--- a/internal/provider/resource_team_member.go
+++ b/internal/provider/resource_team_member.go
@@ -317,12 +317,17 @@ func (r *TeamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	_, _, err := r.client.TeamMembers.Delete(
+	_, apiResp, err := r.client.TeamMembers.Delete(
 		ctx,
 		data.Organization.ValueString(),
 		data.MemberId.ValueString(),
 		data.Team.ValueString(),
 	)
+	// The membership is already gone (e.g. the team was deleted or re-slugged
+	// out-of-band), so treat a 404 as a successful delete.
+	if apiResp != nil && apiResp.StatusCode == http.StatusNotFound {
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.Append(diagutils.NewClientError("delete", err))
 		return

--- a/internal/provider/resource_team_member_test.go
+++ b/internal/provider/resource_team_member_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -53,6 +54,43 @@ func TestAccTeamMemberResource(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"role",
+				},
+			},
+		},
+	})
+}
+
+// TestAccTeamMemberResource_teamDeletedOutOfBand reproduces the case where the
+// team backing a membership is removed from Sentry outside of Terraform (e.g. it
+// was deleted or re-slugged). On destroy, the DELETE against the stale team slug
+// returns 404; the resource must treat that as a successful delete instead of
+// erroring. Without the fix, teardown fails with "Unable to delete, got error:
+// ... 404 The requested resource does not exist".
+func TestAccTeamMemberResource_teamDeletedOutOfBand(t *testing.T) {
+	team := acctest.RandomWithPrefix("tf-team")
+	memberEmail := acctest.RandomWithPrefix("tf-member") + "@example.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTeamMemberConfig_minimumPriority(team, memberEmail, "member", "contributor"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sentry_team_member.test", "organization", acctest.TestOrganization),
+				),
+			},
+			{
+				// Delete the team out-of-band so the membership's team slug no
+				// longer exists, then destroy. The membership's DELETE now 404s
+				// and must be treated as already-deleted rather than an error.
+				Config:  testAccTeamMemberConfig_minimumPriority(team, memberEmail, "member", "contributor"),
+				Destroy: true,
+				PreConfig: func() {
+					_, err := acctest.SharedClient.Teams.Delete(context.Background(), acctest.TestOrganization, team)
+					if err != nil {
+						t.Fatalf("failed to delete team out-of-band: %s", err)
+					}
 				},
 			},
 		},


### PR DESCRIPTION
Fixes the same issue as #783 but on `Delete`.

When the team backing a membership is deleted or re-slugged outside of Terraform, destroying the membership issues a `DELETE` against a team slug that no longer exists and gets back a 404, failing the apply.

Instead of treating every delete error as fatal, this checks the HTTP status directly and returns success on 404, since the membership is already gone.
