### PR TITLE
fix: Gracefull handle 404 when alerts are removed outside of terraform

### DIFF
--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -1127,6 +1127,9 @@ func (r *AlertResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create, got error: %s", err))
 		return
+	} else if httpResp.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
 	} else if httpResp.StatusCode() != http.StatusCreated {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create, got status code %d: %s", httpResp.StatusCode(), string(httpResp.Body)))
 		return


### PR DESCRIPTION
## Description

This PR is updating the `Create` logic of alerts resources in case the resource was manually deleted on Sentry side.

## Why

When an alert is manually deleted in Sentry, terraform is not trying to recreate the alert automatically, it's failing with this error:
```
│ Unable to read, got status code 404: {"detail":"The requested resource does not exist"}
```

## How

By removing the resource from the state in case it's not found, terraform will try to recreate the alert automatically.

**Note**: This is related to this [issue][1], and the fix is similar to what has been done in this [PR][2] for the team member resource.

[1]: https://github.com/jianyuan/terraform-provider-sentry/issues/446
[2]: https://github.com/jianyuan/terraform-provider-sentry/pull/447