### PR TITLE
feat(alert): add Jira ticket fields to sentry_alert

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -238,6 +238,20 @@ resource "sentry_alert" "default" {
             integration_id = data.sentry_organization_integration.jira.id
             project        = "349719"
             issue_type     = "1"
+
+            # Optional Jira fields. All values are IDs, not display names.
+            labels     = "oncall,triage" # comma-separated, not a list
+            components = ["10001"]
+            priority   = "3"
+            reporter   = "5b10ac8d82e05b22cc7d4ef5" # Jira account ID
+
+            # Any other Jira field, keyed by field ID. Sentry rewrites
+            # camelCase keys on write, so camelCase field IDs must be
+            # spelled all-lowercase: `fixversions`, not `fixVersions`.
+            additional_fields = {
+              customfield_10101 = "sre-team"
+              fixversions       = "10500"
+            }
           }
         }
       ]
@@ -268,6 +282,20 @@ resource "sentry_alert" "default" {
             integration_id = data.sentry_organization_integration.jira_server.id
             project        = "349719"
             issue_type     = "1"
+
+            # Optional Jira fields. All values are IDs, not display names.
+            labels     = "oncall,triage" # comma-separated, not a list
+            components = ["10001"]
+            priority   = "3"
+            reporter   = "jira-bot" # Jira Server username
+
+            # Any other Jira field, keyed by field ID. Sentry rewrites
+            # camelCase keys on write, so camelCase field IDs must be
+            # spelled all-lowercase: `fixversions`, not `fixVersions`.
+            additional_fields = {
+              customfield_10101 = "sre-team"
+              fixversions       = "10500"
+            }
           }
         }
       ]
@@ -970,6 +998,14 @@ Required:
 - `issue_type` (String) The ID of the type of issue that the ticket should be created as.
 - `project` (String) The ID of the Jira project.
 
+Optional:
+
+- `additional_fields` (Map of String) Additional Jira fields to set on the created issue, keyed by Jira field ID (e.g. `customfield_10101`). Use this for custom fields and any built-in field not exposed above. Sentry's API converts camelCase keys to snake_case on write, which corrupts them, so camelCase field IDs must be written all-lowercase: use `fixversions`, not `fixVersions`. Jira matches field IDs case-insensitively, so the lowercase spelling resolves to the same field.
+- `components` (Set of String) The IDs of the Jira components to assign to the issue, used for triage routing. These are component IDs, not names.
+- `labels` (String) A comma-separated list of labels to add to the issue (e.g. `oncall,triage`). Note: unlike the `github` action's `labels`, Jira expects a single comma-separated string rather than a list.
+- `priority` (String) The ID of the priority to set on the issue. This is a priority ID, not a name.
+- `reporter` (String) The Jira account ID of the user to set as the reporter of the issue. Useful for attributing automated tickets to a service account.
+
 
 <a id="nestedatt--action_filters--actions--jira_server"></a>
 ### Nested Schema for `action_filters.actions.jira_server`
@@ -979,6 +1015,14 @@ Required:
 - `integration_id` (String) The ID of the Jira Server integration.
 - `issue_type` (String) The ID of the type of issue that the ticket should be created as.
 - `project` (String) The ID of the Jira project.
+
+Optional:
+
+- `additional_fields` (Map of String) Additional Jira Server fields to set on the created issue, keyed by Jira Server field ID (e.g. `customfield_10101`). Use this for custom fields and any built-in field not exposed above. Sentry's API converts camelCase keys to snake_case on write, which corrupts them, so camelCase field IDs must be written all-lowercase: use `fixversions`, not `fixVersions`. Jira matches field IDs case-insensitively, so the lowercase spelling resolves to the same field.
+- `components` (Set of String) The IDs of the Jira Server components to assign to the issue, used for triage routing. These are component IDs, not names.
+- `labels` (String) A comma-separated list of labels to add to the issue (e.g. `oncall,triage`). Note: unlike the `github` action's `labels`, Jira Server expects a single comma-separated string rather than a list.
+- `priority` (String) The ID of the priority to set on the issue. This is a priority ID, not a name.
+- `reporter` (String) The Jira Server username of the user to set as the reporter of the issue. Useful for attributing automated tickets to a service account.
 
 
 <a id="nestedatt--action_filters--actions--msteams"></a>

--- a/examples/resources/sentry_alert/resource-04-jira.tf
+++ b/examples/resources/sentry_alert/resource-04-jira.tf
@@ -17,6 +17,20 @@ resource "sentry_alert" "default" {
             integration_id = data.sentry_organization_integration.jira.id
             project        = "349719"
             issue_type     = "1"
+
+            # Optional Jira fields. All values are IDs, not display names.
+            labels     = "oncall,triage" # comma-separated, not a list
+            components = ["10001"]
+            priority   = "3"
+            reporter   = "5b10ac8d82e05b22cc7d4ef5" # Jira account ID
+
+            # Any other Jira field, keyed by field ID. Sentry rewrites
+            # camelCase keys on write, so camelCase field IDs must be
+            # spelled all-lowercase: `fixversions`, not `fixVersions`.
+            additional_fields = {
+              customfield_10101 = "sre-team"
+              fixversions       = "10500"
+            }
           }
         }
       ]

--- a/examples/resources/sentry_alert/resource-05-jira_server.tf
+++ b/examples/resources/sentry_alert/resource-05-jira_server.tf
@@ -17,6 +17,20 @@ resource "sentry_alert" "default" {
             integration_id = data.sentry_organization_integration.jira_server.id
             project        = "349719"
             issue_type     = "1"
+
+            # Optional Jira fields. All values are IDs, not display names.
+            labels     = "oncall,triage" # comma-separated, not a list
+            components = ["10001"]
+            priority   = "3"
+            reporter   = "jira-bot" # Jira Server username
+
+            # Any other Jira field, keyed by field ID. Sentry rewrites
+            # camelCase keys on write, so camelCase field IDs must be
+            # spelled all-lowercase: `fixversions`, not `fixVersions`.
+            additional_fields = {
+              customfield_10101 = "sre-team"
+              fixversions       = "10500"
+            }
           }
         }
       ]

--- a/internal/apiclient/api.yaml
+++ b/internal/apiclient/api.yaml
@@ -3869,6 +3869,7 @@ components:
           properties:
             additionalFields:
               type: object
+              additionalProperties: true
               required:
                 - project
                 - issuetype
@@ -3876,6 +3877,16 @@ components:
                 project:
                   type: string
                 issuetype:
+                  type: string
+                labels:
+                  type: string
+                components:
+                  type: array
+                  items:
+                    type: string
+                priority:
+                  type: string
+                reporter:
                   type: string
         config:
           type: object
@@ -3907,6 +3918,7 @@ components:
           properties:
             additionalFields:
               type: object
+              additionalProperties: true
               required:
                 - project
                 - issuetype
@@ -3914,6 +3926,16 @@ components:
                 project:
                   type: string
                 issuetype:
+                  type: string
+                labels:
+                  type: string
+                components:
+                  type: array
+                  items:
+                    type: string
+                priority:
+                  type: string
+                reporter:
                   type: string
         config:
           type: object

--- a/internal/apiclient/apiclient.gen.go
+++ b/internal/apiclient/apiclient.gen.go
@@ -1716,10 +1716,7 @@ type OrganizationWorkflowActionFilterActionJira struct {
 		TargetType OrganizationWorkflowActionFilterActionJiraConfigTargetType `json:"targetType"`
 	} `json:"config"`
 	Data struct {
-		AdditionalFields struct {
-			Issuetype string `json:"issuetype"`
-			Project   string `json:"project"`
-		} `json:"additionalFields"`
+		AdditionalFields OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields `json:"additionalFields"`
 	} `json:"data"`
 	IntegrationId string                                         `json:"integrationId"`
 	Type          OrganizationWorkflowActionFilterActionJiraType `json:"type"`
@@ -1727,6 +1724,17 @@ type OrganizationWorkflowActionFilterActionJira struct {
 
 // OrganizationWorkflowActionFilterActionJiraConfigTargetType defines model for OrganizationWorkflowActionFilterActionJira.Config.TargetType.
 type OrganizationWorkflowActionFilterActionJiraConfigTargetType string
+
+// OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields defines model for OrganizationWorkflowActionFilterActionJira.Data.AdditionalFields.
+type OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields struct {
+	Components           *[]string              `json:"components,omitempty"`
+	Issuetype            string                 `json:"issuetype"`
+	Labels               *string                `json:"labels,omitempty"`
+	Priority             *string                `json:"priority,omitempty"`
+	Project              string                 `json:"project"`
+	Reporter             *string                `json:"reporter,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
 
 // OrganizationWorkflowActionFilterActionJiraType defines model for OrganizationWorkflowActionFilterActionJira.Type.
 type OrganizationWorkflowActionFilterActionJiraType string
@@ -1737,10 +1745,7 @@ type OrganizationWorkflowActionFilterActionJiraServer struct {
 		TargetType OrganizationWorkflowActionFilterActionJiraServerConfigTargetType `json:"targetType"`
 	} `json:"config"`
 	Data struct {
-		AdditionalFields struct {
-			Issuetype string `json:"issuetype"`
-			Project   string `json:"project"`
-		} `json:"additionalFields"`
+		AdditionalFields OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields `json:"additionalFields"`
 	} `json:"data"`
 	IntegrationId string                                               `json:"integrationId"`
 	Type          OrganizationWorkflowActionFilterActionJiraServerType `json:"type"`
@@ -1748,6 +1753,17 @@ type OrganizationWorkflowActionFilterActionJiraServer struct {
 
 // OrganizationWorkflowActionFilterActionJiraServerConfigTargetType defines model for OrganizationWorkflowActionFilterActionJiraServer.Config.TargetType.
 type OrganizationWorkflowActionFilterActionJiraServerConfigTargetType string
+
+// OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields defines model for OrganizationWorkflowActionFilterActionJiraServer.Data.AdditionalFields.
+type OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields struct {
+	Components           *[]string              `json:"components,omitempty"`
+	Issuetype            string                 `json:"issuetype"`
+	Labels               *string                `json:"labels,omitempty"`
+	Priority             *string                `json:"priority,omitempty"`
+	Project              string                 `json:"project"`
+	Reporter             *string                `json:"reporter,omitempty"`
+	AdditionalProperties map[string]interface{} `json:"-"`
+}
 
 // OrganizationWorkflowActionFilterActionJiraServerType defines model for OrganizationWorkflowActionFilterActionJiraServer.Type.
 type OrganizationWorkflowActionFilterActionJiraServerType string
@@ -3259,6 +3275,284 @@ type UpdateProjectRuleJSONRequestBody UpdateProjectRuleJSONBody
 
 // CreateOrganizationTeamProjectJSONRequestBody defines body for CreateOrganizationTeamProject for application/json ContentType.
 type CreateOrganizationTeamProjectJSONRequestBody CreateOrganizationTeamProjectJSONBody
+
+// Getter for additional properties for OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields. Returns the specified
+// element and whether it was found
+func (a OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields
+func (a *OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields to handle AdditionalProperties
+func (a *OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["components"]; found {
+		err = json.Unmarshal(raw, &a.Components)
+		if err != nil {
+			return fmt.Errorf("error reading 'components': %w", err)
+		}
+		delete(object, "components")
+	}
+
+	if raw, found := object["issuetype"]; found {
+		err = json.Unmarshal(raw, &a.Issuetype)
+		if err != nil {
+			return fmt.Errorf("error reading 'issuetype': %w", err)
+		}
+		delete(object, "issuetype")
+	}
+
+	if raw, found := object["labels"]; found {
+		err = json.Unmarshal(raw, &a.Labels)
+		if err != nil {
+			return fmt.Errorf("error reading 'labels': %w", err)
+		}
+		delete(object, "labels")
+	}
+
+	if raw, found := object["priority"]; found {
+		err = json.Unmarshal(raw, &a.Priority)
+		if err != nil {
+			return fmt.Errorf("error reading 'priority': %w", err)
+		}
+		delete(object, "priority")
+	}
+
+	if raw, found := object["project"]; found {
+		err = json.Unmarshal(raw, &a.Project)
+		if err != nil {
+			return fmt.Errorf("error reading 'project': %w", err)
+		}
+		delete(object, "project")
+	}
+
+	if raw, found := object["reporter"]; found {
+		err = json.Unmarshal(raw, &a.Reporter)
+		if err != nil {
+			return fmt.Errorf("error reading 'reporter': %w", err)
+		}
+		delete(object, "reporter")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields to handle AdditionalProperties
+func (a OrganizationWorkflowActionFilterActionJira_Data_AdditionalFields) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Components != nil {
+		object["components"], err = json.Marshal(a.Components)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'components': %w", err)
+		}
+	}
+
+	object["issuetype"], err = json.Marshal(a.Issuetype)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'issuetype': %w", err)
+	}
+
+	if a.Labels != nil {
+		object["labels"], err = json.Marshal(a.Labels)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'labels': %w", err)
+		}
+	}
+
+	if a.Priority != nil {
+		object["priority"], err = json.Marshal(a.Priority)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'priority': %w", err)
+		}
+	}
+
+	object["project"], err = json.Marshal(a.Project)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'project': %w", err)
+	}
+
+	if a.Reporter != nil {
+		object["reporter"], err = json.Marshal(a.Reporter)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'reporter': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
+
+// Getter for additional properties for OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields. Returns the specified
+// element and whether it was found
+func (a OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields) Get(fieldName string) (value interface{}, found bool) {
+	if a.AdditionalProperties != nil {
+		value, found = a.AdditionalProperties[fieldName]
+	}
+	return
+}
+
+// Setter for additional properties for OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields
+func (a *OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields) Set(fieldName string, value interface{}) {
+	if a.AdditionalProperties == nil {
+		a.AdditionalProperties = make(map[string]interface{})
+	}
+	a.AdditionalProperties[fieldName] = value
+}
+
+// Override default JSON handling for OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields to handle AdditionalProperties
+func (a *OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields) UnmarshalJSON(b []byte) error {
+	object := make(map[string]json.RawMessage)
+	err := json.Unmarshal(b, &object)
+	if err != nil {
+		return err
+	}
+
+	if raw, found := object["components"]; found {
+		err = json.Unmarshal(raw, &a.Components)
+		if err != nil {
+			return fmt.Errorf("error reading 'components': %w", err)
+		}
+		delete(object, "components")
+	}
+
+	if raw, found := object["issuetype"]; found {
+		err = json.Unmarshal(raw, &a.Issuetype)
+		if err != nil {
+			return fmt.Errorf("error reading 'issuetype': %w", err)
+		}
+		delete(object, "issuetype")
+	}
+
+	if raw, found := object["labels"]; found {
+		err = json.Unmarshal(raw, &a.Labels)
+		if err != nil {
+			return fmt.Errorf("error reading 'labels': %w", err)
+		}
+		delete(object, "labels")
+	}
+
+	if raw, found := object["priority"]; found {
+		err = json.Unmarshal(raw, &a.Priority)
+		if err != nil {
+			return fmt.Errorf("error reading 'priority': %w", err)
+		}
+		delete(object, "priority")
+	}
+
+	if raw, found := object["project"]; found {
+		err = json.Unmarshal(raw, &a.Project)
+		if err != nil {
+			return fmt.Errorf("error reading 'project': %w", err)
+		}
+		delete(object, "project")
+	}
+
+	if raw, found := object["reporter"]; found {
+		err = json.Unmarshal(raw, &a.Reporter)
+		if err != nil {
+			return fmt.Errorf("error reading 'reporter': %w", err)
+		}
+		delete(object, "reporter")
+	}
+
+	if len(object) != 0 {
+		a.AdditionalProperties = make(map[string]interface{})
+		for fieldName, fieldBuf := range object {
+			var fieldVal interface{}
+			err := json.Unmarshal(fieldBuf, &fieldVal)
+			if err != nil {
+				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
+			}
+			a.AdditionalProperties[fieldName] = fieldVal
+		}
+	}
+	return nil
+}
+
+// Override default JSON handling for OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields to handle AdditionalProperties
+func (a OrganizationWorkflowActionFilterActionJiraServer_Data_AdditionalFields) MarshalJSON() ([]byte, error) {
+	var err error
+	object := make(map[string]json.RawMessage)
+
+	if a.Components != nil {
+		object["components"], err = json.Marshal(a.Components)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'components': %w", err)
+		}
+	}
+
+	object["issuetype"], err = json.Marshal(a.Issuetype)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'issuetype': %w", err)
+	}
+
+	if a.Labels != nil {
+		object["labels"], err = json.Marshal(a.Labels)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'labels': %w", err)
+		}
+	}
+
+	if a.Priority != nil {
+		object["priority"], err = json.Marshal(a.Priority)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'priority': %w", err)
+		}
+	}
+
+	object["project"], err = json.Marshal(a.Project)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling 'project': %w", err)
+	}
+
+	if a.Reporter != nil {
+		object["reporter"], err = json.Marshal(a.Reporter)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling 'reporter': %w", err)
+		}
+	}
+
+	for fieldName, field := range a.AdditionalProperties {
+		object[fieldName], err = json.Marshal(field)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
+		}
+	}
+	return json.Marshal(object)
+}
 
 // AsOrganizationIntegrationOpsgenie returns the union data inside the OrganizationIntegration as a OrganizationIntegrationOpsgenie
 func (t OrganizationIntegration) AsOrganizationIntegrationOpsgenie() (OrganizationIntegrationOpsgenie, error) {

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -979,6 +980,34 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												Required:            true,
 												CustomType:          supertypes.StringType{},
 											},
+											"labels": schema.StringAttribute{
+												MarkdownDescription: "A comma-separated list of labels to add to the issue (e.g. `oncall,triage`). Note: unlike the `github` action's `labels`, Jira expects a single comma-separated string rather than a list.",
+												Optional:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"components": schema.SetAttribute{
+												MarkdownDescription: "The IDs of the Jira components to assign to the issue, used for triage routing. These are component IDs, not names.",
+												Optional:            true,
+												CustomType:          supertypes.NewSetTypeOf[string](ctx),
+											},
+											"priority": schema.StringAttribute{
+												MarkdownDescription: "The ID of the priority to set on the issue. This is a priority ID, not a name.",
+												Optional:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"reporter": schema.StringAttribute{
+												MarkdownDescription: "The Jira account ID of the user to set as the reporter of the issue. Useful for attributing automated tickets to a service account.",
+												Optional:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"additional_fields": schema.MapAttribute{
+												MarkdownDescription: "Additional Jira fields to set on the created issue, keyed by Jira field ID (e.g. `customfield_10101`). Use this for custom fields and any built-in field not exposed above. Sentry's API converts camelCase keys to snake_case on write, which corrupts them, so camelCase field IDs must be written all-lowercase: use `fixversions`, not `fixVersions`. Jira matches field IDs case-insensitively, so the lowercase spelling resolves to the same field.",
+												Optional:            true,
+												CustomType:          supertypes.NewMapTypeOf[string](ctx),
+												Validators: []validator.Map{
+													mapvalidator.KeysAre(ticketAdditionalFieldKeyValidator()),
+												},
+											},
 										},
 									},
 									"jira_server": schema.SingleNestedAttribute{
@@ -1003,6 +1032,34 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 												MarkdownDescription: "The ID of the type of issue that the ticket should be created as.",
 												Required:            true,
 												CustomType:          supertypes.StringType{},
+											},
+											"labels": schema.StringAttribute{
+												MarkdownDescription: "A comma-separated list of labels to add to the issue (e.g. `oncall,triage`). Note: unlike the `github` action's `labels`, Jira Server expects a single comma-separated string rather than a list.",
+												Optional:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"components": schema.SetAttribute{
+												MarkdownDescription: "The IDs of the Jira Server components to assign to the issue, used for triage routing. These are component IDs, not names.",
+												Optional:            true,
+												CustomType:          supertypes.NewSetTypeOf[string](ctx),
+											},
+											"priority": schema.StringAttribute{
+												MarkdownDescription: "The ID of the priority to set on the issue. This is a priority ID, not a name.",
+												Optional:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"reporter": schema.StringAttribute{
+												MarkdownDescription: "The Jira Server username of the user to set as the reporter of the issue. Useful for attributing automated tickets to a service account.",
+												Optional:            true,
+												CustomType:          supertypes.StringType{},
+											},
+											"additional_fields": schema.MapAttribute{
+												MarkdownDescription: "Additional Jira Server fields to set on the created issue, keyed by Jira Server field ID (e.g. `customfield_10101`). Use this for custom fields and any built-in field not exposed above. Sentry's API converts camelCase keys to snake_case on write, which corrupts them, so camelCase field IDs must be written all-lowercase: use `fixversions`, not `fixVersions`. Jira matches field IDs case-insensitively, so the lowercase spelling resolves to the same field.",
+												Optional:            true,
+												CustomType:          supertypes.NewMapTypeOf[string](ctx),
+												Validators: []validator.Map{
+													mapvalidator.KeysAre(ticketAdditionalFieldKeyValidator()),
+												},
 											},
 										},
 									},
@@ -1485,15 +1542,25 @@ type AlertResourceModelActionFiltersItemActionsItemVsts struct {
 }
 
 type AlertResourceModelActionFiltersItemActionsItemJira struct {
-	IntegrationId supertypes.StringValue `tfsdk:"integration_id"`
-	Project       supertypes.StringValue `tfsdk:"project"`
-	IssueType     supertypes.StringValue `tfsdk:"issue_type"`
+	IntegrationId    supertypes.StringValue        `tfsdk:"integration_id"`
+	Project          supertypes.StringValue        `tfsdk:"project"`
+	IssueType        supertypes.StringValue        `tfsdk:"issue_type"`
+	Labels           supertypes.StringValue        `tfsdk:"labels"`
+	Components       supertypes.SetValueOf[string] `tfsdk:"components"`
+	Priority         supertypes.StringValue        `tfsdk:"priority"`
+	Reporter         supertypes.StringValue        `tfsdk:"reporter"`
+	AdditionalFields supertypes.MapValueOf[string] `tfsdk:"additional_fields"`
 }
 
 type AlertResourceModelActionFiltersItemActionsItemJiraServer struct {
-	IntegrationId supertypes.StringValue `tfsdk:"integration_id"`
-	Project       supertypes.StringValue `tfsdk:"project"`
-	IssueType     supertypes.StringValue `tfsdk:"issue_type"`
+	IntegrationId    supertypes.StringValue        `tfsdk:"integration_id"`
+	Project          supertypes.StringValue        `tfsdk:"project"`
+	IssueType        supertypes.StringValue        `tfsdk:"issue_type"`
+	Labels           supertypes.StringValue        `tfsdk:"labels"`
+	Components       supertypes.SetValueOf[string] `tfsdk:"components"`
+	Priority         supertypes.StringValue        `tfsdk:"priority"`
+	Reporter         supertypes.StringValue        `tfsdk:"reporter"`
+	AdditionalFields supertypes.MapValueOf[string] `tfsdk:"additional_fields"`
 }
 
 type AlertResourceModelActionFiltersItemActionsItemGithub struct {

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -532,6 +532,18 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				outJira.Config.TargetType = "specific"
 				outJira.Data.AdditionalFields.Project = inJira.Project.Get()
 				outJira.Data.AdditionalFields.Issuetype = inJira.IssueType.Get()
+				outJira.Data.AdditionalFields.Labels = inJira.Labels.GetPtr()
+				outJira.Data.AdditionalFields.Priority = inJira.Priority.GetPtr()
+				outJira.Data.AdditionalFields.Reporter = inJira.Reporter.GetPtr()
+				if inJira.Components.IsKnown() {
+					components := inJira.Components.DiagsGet(ctx, diags)
+					outJira.Data.AdditionalFields.Components = &components
+				}
+				if inJira.AdditionalFields.IsKnown() {
+					for k, v := range inJira.AdditionalFields.DiagsGet(ctx, diags) {
+						outJira.Data.AdditionalFields.Set(k, v)
+					}
+				}
 				if diags.HasError() {
 					return nil, diags
 				}
@@ -552,6 +564,18 @@ func (r *AlertResource) getActionFilters(ctx context.Context, data AlertResource
 				outJiraServer.Config.TargetType = "specific"
 				outJiraServer.Data.AdditionalFields.Project = inJiraServer.Project.Get()
 				outJiraServer.Data.AdditionalFields.Issuetype = inJiraServer.IssueType.Get()
+				outJiraServer.Data.AdditionalFields.Labels = inJiraServer.Labels.GetPtr()
+				outJiraServer.Data.AdditionalFields.Priority = inJiraServer.Priority.GetPtr()
+				outJiraServer.Data.AdditionalFields.Reporter = inJiraServer.Reporter.GetPtr()
+				if inJiraServer.Components.IsKnown() {
+					components := inJiraServer.Components.DiagsGet(ctx, diags)
+					outJiraServer.Data.AdditionalFields.Components = &components
+				}
+				if inJiraServer.AdditionalFields.IsKnown() {
+					for k, v := range inJiraServer.AdditionalFields.DiagsGet(ctx, diags) {
+						outJiraServer.Data.AdditionalFields.Set(k, v)
+					}
+				}
 				if diags.HasError() {
 					return nil, diags
 				}
@@ -1177,6 +1201,11 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				outJira.IntegrationId = supertypes.NewStringValue(actionValue.IntegrationId)
 				outJira.Project = supertypes.NewStringValue(actionValue.Data.AdditionalFields.Project)
 				outJira.IssueType = supertypes.NewStringValue(actionValue.Data.AdditionalFields.Issuetype)
+				outJira.Labels = newOptionalTicketString(actionValue.Data.AdditionalFields.Labels)
+				outJira.Priority = newOptionalTicketString(actionValue.Data.AdditionalFields.Priority)
+				outJira.Reporter = newOptionalTicketString(actionValue.Data.AdditionalFields.Reporter)
+				outJira.Components = newOptionalTicketStringSet(ctx, actionValue.Data.AdditionalFields.Components)
+				outJira.AdditionalFields = newOptionalTicketAdditionalFields(ctx, actionValue.Data.AdditionalFields.AdditionalProperties, &diags)
 
 				outAction.Jira = supertypes.NewSingleNestedObjectValueOf(ctx, &outJira)
 
@@ -1185,6 +1214,11 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 				outJiraServer.IntegrationId = supertypes.NewStringValue(actionValue.IntegrationId)
 				outJiraServer.Project = supertypes.NewStringValue(actionValue.Data.AdditionalFields.Project)
 				outJiraServer.IssueType = supertypes.NewStringValue(actionValue.Data.AdditionalFields.Issuetype)
+				outJiraServer.Labels = newOptionalTicketString(actionValue.Data.AdditionalFields.Labels)
+				outJiraServer.Priority = newOptionalTicketString(actionValue.Data.AdditionalFields.Priority)
+				outJiraServer.Reporter = newOptionalTicketString(actionValue.Data.AdditionalFields.Reporter)
+				outJiraServer.Components = newOptionalTicketStringSet(ctx, actionValue.Data.AdditionalFields.Components)
+				outJiraServer.AdditionalFields = newOptionalTicketAdditionalFields(ctx, actionValue.Data.AdditionalFields.AdditionalProperties, &diags)
 
 				outAction.JiraServer = supertypes.NewSingleNestedObjectValueOf(ctx, &outJiraServer)
 
@@ -1242,4 +1276,66 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 	m.ActionFilters = supertypes.NewListNestedObjectValueOfValueSlice(ctx, outActionFilters)
 
 	return
+}
+
+// newOptionalTicketString converts an optional ticket `additionalFields` string
+// into a Terraform value. Sentry stores unset ticket fields inconsistently --
+// the key may be absent, or present with an empty string -- and both mean "not
+// set". Normalising both to null keeps an omitted attribute from showing
+// permanent drift after apply.
+func newOptionalTicketString(value *string) supertypes.StringValue {
+	if value == nil || *value == "" {
+		return supertypes.NewStringNull()
+	}
+	return supertypes.NewStringValue(*value)
+}
+
+// newOptionalTicketStringSet converts an optional ticket `additionalFields`
+// string list into a Terraform set, mapping both an absent key and an empty
+// list to null for the same reason as newOptionalTicketString.
+func newOptionalTicketStringSet(ctx context.Context, values *[]string) supertypes.SetValueOf[string] {
+	if values == nil || len(*values) == 0 {
+		return supertypes.NewSetValueOfNull[string](ctx)
+	}
+	return supertypes.NewSetValueOfSlice(ctx, *values)
+}
+
+// newOptionalTicketAdditionalFields converts the passthrough `additionalFields`
+// keys that have no dedicated attribute into a Terraform map. Values are
+// stringified because the schema models them as a map of strings; Sentry echoes
+// back whatever JSON scalar it was given, so a number written as "3" returns as
+// 3 and must be normalised to avoid drift.
+func newOptionalTicketAdditionalFields(ctx context.Context, values map[string]interface{}, diags *diag.Diagnostics) supertypes.MapValueOf[string] {
+	if len(values) == 0 {
+		return supertypes.NewMapValueOfNull[string](ctx)
+	}
+
+	out := make(map[string]string, len(values))
+	for k, v := range values {
+		switch tv := v.(type) {
+		case nil:
+			continue
+		case string:
+			out[k] = tv
+		case json.Number:
+			out[k] = tv.String()
+		case float64:
+			out[k] = strconv.FormatFloat(tv, 'f', -1, 64)
+		case bool:
+			out[k] = strconv.FormatBool(tv)
+		default:
+			b, err := json.Marshal(tv)
+			if err != nil {
+				continue
+			}
+			out[k] = string(b)
+		}
+	}
+
+	if len(out) == 0 {
+		return supertypes.NewMapValueOfNull[string](ctx)
+	}
+	v, d := supertypes.NewMapValueOfMap(ctx, out)
+	diags.Append(d...)
+	return v
 }

--- a/internal/provider/resource_alert_unit_test.go
+++ b/internal/provider/resource_alert_unit_test.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestNewOptionalTicketString(t *testing.T) {
+	// Sentry reports an unset ticket field either by omitting the key or by
+	// returning an empty string. Both must normalise to null, otherwise an
+	// attribute the user never set shows permanent drift after apply.
+	for _, tt := range []struct {
+		name     string
+		value    *string
+		wantNull bool
+		wantStr  string
+	}{
+		{name: "absent key", value: nil, wantNull: true},
+		{name: "empty string", value: ptr(""), wantNull: true},
+		{name: "set value", value: ptr("oncall,triage"), wantStr: "oncall,triage"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newOptionalTicketString(tt.value)
+			if tt.wantNull {
+				if !got.IsNull() {
+					t.Fatalf("expected null, got %q", got.Get())
+				}
+				return
+			}
+			if got.IsNull() {
+				t.Fatal("expected a value, got null")
+			}
+			if got.Get() != tt.wantStr {
+				t.Fatalf("expected %q, got %q", tt.wantStr, got.Get())
+			}
+		})
+	}
+}
+
+func TestNewOptionalTicketStringSet(t *testing.T) {
+	ctx := context.Background()
+
+	if got := newOptionalTicketStringSet(ctx, nil); !got.IsNull() {
+		t.Fatal("expected null for an absent components key")
+	}
+
+	if got := newOptionalTicketStringSet(ctx, &[]string{}); !got.IsNull() {
+		t.Fatal("expected null for an empty components list")
+	}
+
+	got := newOptionalTicketStringSet(ctx, &[]string{"10001", "10002"})
+	if got.IsNull() {
+		t.Fatal("expected a value for a populated components list")
+	}
+	var diags diag.Diagnostics
+	elems := got.DiagsGet(ctx, diags)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if len(elems) != 2 {
+		t.Fatalf("expected 2 components, got %d", len(elems))
+	}
+}
+
+func ptr(s string) *string { return &s }
+
+func TestCamelToSnakeCase(t *testing.T) {
+	// Mirrors Django's re_camel_case, which Sentry applies to every incoming
+	// payload key. Used to tell the user what their key would be turned into.
+	for in, want := range map[string]string{
+		"fixVersions":       "fix_versions",
+		"dueDate":           "due_date",
+		"lastViewed":        "last_viewed",
+		"FixVersions":       "fix_versions",
+		"FIXVERSIONS":       "fixversions",
+		"labels":            "labels",
+		"customfield_10101": "customfield_10101",
+	} {
+		if got := camelToSnakeCase(in); got != want {
+			t.Errorf("camelToSnakeCase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTicketAdditionalFieldKeyValidator(t *testing.T) {
+	ctx := context.Background()
+	v := ticketAdditionalFieldKeyValidator()
+
+	for _, tt := range []struct {
+		key     string
+		wantErr bool
+	}{
+		// Keys that survive Sentry's conversion unchanged.
+		{key: "customfield_10101"},
+		{key: "fixversions"},
+		{key: "duedate"},
+		// Pure case changes are harmless: Sentry stores "upper", and Jira
+		// lowercases both sides when matching, so it resolves to the same
+		// field. Verified against the live API.
+		{key: "UPPER"},
+		{key: "Environment"},
+		// An inserted underscore does break the field.
+		{key: "fixVersions", wantErr: true},
+		{key: "dueDate", wantErr: true},
+		{key: "MixedCase", wantErr: true},
+		// Reserved: has a dedicated attribute, or is set by Sentry itself.
+		{key: "labels", wantErr: true},
+		{key: "project", wantErr: true},
+		{key: "description", wantErr: true},
+		{key: "dynamic_form_fields", wantErr: true},
+		// Reserved keys must be caught in their post-conversion form too --
+		// "Labels" is stored as "labels" and would collide with the dedicated
+		// attribute just the same.
+		{key: "Labels", wantErr: true},
+		{key: "PRIORITY", wantErr: true},
+	} {
+		t.Run(tt.key, func(t *testing.T) {
+			req := validator.StringRequest{
+				Path:        path.Root("additional_fields"),
+				ConfigValue: types.StringValue(tt.key),
+			}
+			resp := &validator.StringResponse{}
+			v.ValidateString(ctx, req, resp)
+
+			if got := resp.Diagnostics.HasError(); got != tt.wantErr {
+				t.Fatalf("key %q: HasError() = %t, want %t (%v)", tt.key, got, tt.wantErr, resp.Diagnostics)
+			}
+		})
+	}
+}
+
+// TestTicketAdditionalFieldsOverwriteTypedAttribute documents why the reserved
+// key check is needed independently of Sentry's camelCase bug: the generated
+// marshaller writes AdditionalProperties after the typed fields, into the same
+// JSON object, so a passthrough key silently wins.
+func TestTicketAdditionalFieldsOverwriteTypedAttribute(t *testing.T) {
+	var action apiclient.OrganizationWorkflowActionFilterActionJira
+	action.Data.AdditionalFields.Project = "10000"
+	action.Data.AdditionalFields.Issuetype = "10001"
+	labels := "oncall,triage"
+	action.Data.AdditionalFields.Labels = &labels
+
+	action.Data.AdditionalFields.Set("labels", "clobbered")
+
+	encoded, err := json.Marshal(action.Data.AdditionalFields)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded["labels"] != "clobbered" {
+		t.Fatalf("expected the passthrough value to win (documenting the collision), got %v", decoded["labels"])
+	}
+
+	// The validator is what stops a user from reaching that state.
+	resp := &validator.StringResponse{}
+	ticketAdditionalFieldKeyValidator().ValidateString(
+		context.Background(),
+		validator.StringRequest{
+			Path:        path.Root("additional_fields"),
+			ConfigValue: types.StringValue("labels"),
+		},
+		resp,
+	)
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected the validator to reject a key that collides with a dedicated attribute")
+	}
+}

--- a/internal/provider/ticket_additional_fields.go
+++ b/internal/provider/ticket_additional_fields.go
@@ -1,0 +1,155 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// reservedTicketAdditionalFieldKeys are keys that must not appear in
+// `additional_fields`, either because the action exposes a dedicated attribute
+// for them or because Sentry populates them itself when the ticket is created.
+var reservedTicketAdditionalFieldKeys = []string{
+	// Have a dedicated attribute on the ticket action.
+	"project",
+	"issuetype",
+	"labels",
+	"components",
+	"priority",
+	"reporter",
+	"integration",
+	// Set by Sentry when the ticket is created.
+	"title",
+	"description",
+	"summary",
+	"dynamic_form_fields",
+}
+
+// ticketAdditionalFieldKeyValidator rejects `additional_fields` keys that would
+// not survive a round trip. It enforces two independent rules; see
+// validateTicketFieldKeyCollision and validateTicketFieldKeyCasing.
+func ticketAdditionalFieldKeyValidator() validator.String {
+	return ticketAdditionalFieldKeyValidatorImpl{}
+}
+
+type ticketAdditionalFieldKeyValidatorImpl struct{}
+
+func (v ticketAdditionalFieldKeyValidatorImpl) Description(ctx context.Context) string {
+	return "key must survive Sentry's snake_case conversion unchanged and must not duplicate a dedicated attribute"
+}
+
+func (v ticketAdditionalFieldKeyValidatorImpl) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v ticketAdditionalFieldKeyValidatorImpl) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	key := req.ConfigValue.ValueString()
+
+	// Sentry stores the converted form of the key, so both checks compare
+	// against that rather than against what the user typed.
+	stored := camelToSnakeCase(key)
+
+	if validateTicketFieldKeyCasing(req, resp, key, stored); resp.Diagnostics.HasError() {
+		return
+	}
+
+	validateTicketFieldKeyCollision(req, resp, key, stored)
+}
+
+// validateTicketFieldKeyCollision rejects keys that collide with a dedicated
+// attribute or with a value Sentry sets itself.
+//
+// This guards a provider-side bug, not an API one, and is required
+// indefinitely. The generated `additionalFields` marshaller writes
+// AdditionalProperties into the same JSON object *after* the typed fields, so a
+// passthrough key silently overwrites the dedicated attribute. In practice that
+// means `additional_fields = { labels = "x" }` discards whatever the `labels`
+// attribute was set to, Terraform reports "Provider produced inconsistent
+// result after apply", and the resource is left orphaned in Sentry.
+func validateTicketFieldKeyCollision(req validator.StringRequest, resp *validator.StringResponse, key, stored string) {
+	for _, reserved := range reservedTicketAdditionalFieldKeys {
+		if stored != reserved {
+			continue
+		}
+
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid additional field key",
+			fmt.Sprintf(
+				"The key %q is set by Sentry or has a dedicated attribute on this action. "+
+					"Setting it here would silently override that attribute. Set it there instead.",
+				key,
+			),
+		)
+		return
+	}
+}
+
+// validateTicketFieldKeyCasing rejects keys that Sentry's API would rewrite.
+//
+// TODO: remove this check, camelToSnakeCase, and their tests once
+// getsentry/sentry#122398 has shipped and the provider's minimum supported
+// Sentry version includes it. It exists solely to work around an upstream
+// asymmetry: `TicketingActionHandler.serialize_data` exempts
+// `additional_fields` from case conversion when reading, but the write path
+// (`BaseActionValidator`, via `CamelSnakeSerializer.__init__`) runs
+// camel_to_snake_case recursively with no such exemption, so third-party field
+// IDs are mangled on the way in. That PR exempts nested keys under
+// `additional_fields`, after which camelCase field IDs round-trip verbatim and
+// rejecting them here would be wrong.
+//
+// Note this only affects Sentry SaaS and self-hosted versions predating the
+// fix; the collision check above is unrelated and stays.
+//
+// Only an inserted underscore actually breaks the field. Jira Cloud lowercases
+// both the payload key and the Jira field ID before matching, so a pure case
+// change (`UPPER` -> `upper`) still resolves to the same field; `fixVersions`
+// -> `fix_versions` does not, and Jira Server matches its field ID exactly so
+// it drops the value with no error at all. Hence the test is whether conversion
+// changes the key by more than lowercasing it.
+func validateTicketFieldKeyCasing(req validator.StringRequest, resp *validator.StringResponse, key, stored string) {
+	if stored == strings.ToLower(key) {
+		return
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid additional field key",
+		fmt.Sprintf(
+			"Sentry's API converts camelCase keys to snake_case when storing them, which would change "+
+				"%[1]q to %[2]q and drop the field when the ticket is created. Use the all-lowercase "+
+				"spelling %[3]q instead -- Jira matches field IDs case-insensitively, so it resolves to "+
+				"the same field.",
+			key, stored, strings.ToLower(key),
+		),
+	)
+}
+
+// camelToSnakeCase mirrors Django's re_camel_case substitution, which Sentry
+// applies to incoming payload keys. It is used to determine the key Sentry will
+// actually store, and to show the user what their key would be turned into.
+func camelToSnakeCase(value string) string {
+	var b strings.Builder
+	runes := []rune(value)
+	for i, r := range runes {
+		isUpper := r >= 'A' && r <= 'Z'
+		if isUpper && i > 0 {
+			prev := runes[i-1]
+			prevIsLower := prev >= 'a' && prev <= 'z'
+			// Mirrors Django's `[A-Z](?![A-Z]|$)`: a run-final uppercase only splits
+			// when followed by a lowercase character, not at end of string.
+			nextIsNotUpper := i+1 < len(runes) && !(runes[i+1] >= 'A' && runes[i+1] <= 'Z')
+			if prevIsLower || nextIsNotUpper {
+				b.WriteRune('_')
+			}
+		}
+		b.WriteRune(r)
+	}
+	return strings.Trim(strings.ToLower(b.String()), "_")
+}

--- a/internal/provider/ticket_additional_fields.go
+++ b/internal/provider/ticket_additional_fields.go
@@ -144,7 +144,7 @@ func camelToSnakeCase(value string) string {
 			prevIsLower := prev >= 'a' && prev <= 'z'
 			// Mirrors Django's `[A-Z](?![A-Z]|$)`: a run-final uppercase only splits
 			// when followed by a lowercase character, not at end of string.
-			nextIsNotUpper := i+1 < len(runes) && !(runes[i+1] >= 'A' && runes[i+1] <= 'Z')
+			nextIsNotUpper := i+1 < len(runes) && (runes[i+1] < 'A' || runes[i+1] > 'Z')
 			if prevIsLower || nextIsNotUpper {
 				b.WriteRune('_')
 			}

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -974,6 +974,46 @@ export default {
                     "The ID of the type of issue that the ticket should be created as.",
                   computedOptionalRequired: "required",
                 },
+                {
+                  name: "labels",
+                  type: "string",
+                  description:
+                    "A comma-separated list of labels to add to the issue (e.g. `oncall,triage`). Note: unlike the `github` action's `labels`, Jira expects a single comma-separated string rather than a list.",
+                  computedOptionalRequired: "optional",
+                },
+                {
+                  name: "components",
+                  type: "set",
+                  description:
+                    "The IDs of the Jira components to assign to the issue, used for triage routing. These are component IDs, not names.",
+                  computedOptionalRequired: "optional",
+                  elementType: "string",
+                },
+                {
+                  name: "priority",
+                  type: "string",
+                  description:
+                    "The ID of the priority to set on the issue. This is a priority ID, not a name.",
+                  computedOptionalRequired: "optional",
+                },
+                {
+                  name: "reporter",
+                  type: "string",
+                  description:
+                    "The Jira account ID of the user to set as the reporter of the issue. Useful for attributing automated tickets to a service account.",
+                  computedOptionalRequired: "optional",
+                },
+                {
+                  name: "additional_fields",
+                  type: "map",
+                  description:
+                    "Additional Jira fields to set on the created issue, keyed by Jira field ID (e.g. `customfield_10101`). Use this for custom fields and any built-in field not exposed above. Sentry's API converts camelCase keys to snake_case on write, which corrupts them, so camelCase field IDs must be written all-lowercase: use `fixversions`, not `fixVersions`. Jira matches field IDs case-insensitively, so the lowercase spelling resolves to the same field.",
+                  computedOptionalRequired: "optional",
+                  elementType: "string",
+                  validators: [
+                    `mapvalidator.KeysAre(ticketAdditionalFieldKeyValidator())`,
+                  ],
+                },
               ],
             },
             {
@@ -1000,6 +1040,46 @@ export default {
                   description:
                     "The ID of the type of issue that the ticket should be created as.",
                   computedOptionalRequired: "required",
+                },
+                {
+                  name: "labels",
+                  type: "string",
+                  description:
+                    "A comma-separated list of labels to add to the issue (e.g. `oncall,triage`). Note: unlike the `github` action's `labels`, Jira Server expects a single comma-separated string rather than a list.",
+                  computedOptionalRequired: "optional",
+                },
+                {
+                  name: "components",
+                  type: "set",
+                  description:
+                    "The IDs of the Jira Server components to assign to the issue, used for triage routing. These are component IDs, not names.",
+                  computedOptionalRequired: "optional",
+                  elementType: "string",
+                },
+                {
+                  name: "priority",
+                  type: "string",
+                  description:
+                    "The ID of the priority to set on the issue. This is a priority ID, not a name.",
+                  computedOptionalRequired: "optional",
+                },
+                {
+                  name: "reporter",
+                  type: "string",
+                  description:
+                    "The Jira Server username of the user to set as the reporter of the issue. Useful for attributing automated tickets to a service account.",
+                  computedOptionalRequired: "optional",
+                },
+                {
+                  name: "additional_fields",
+                  type: "map",
+                  description:
+                    "Additional Jira Server fields to set on the created issue, keyed by Jira Server field ID (e.g. `customfield_10101`). Use this for custom fields and any built-in field not exposed above. Sentry's API converts camelCase keys to snake_case on write, which corrupts them, so camelCase field IDs must be written all-lowercase: use `fixversions`, not `fixVersions`. Jira matches field IDs case-insensitively, so the lowercase spelling resolves to the same field.",
+                  computedOptionalRequired: "optional",
+                  elementType: "string",
+                  validators: [
+                    `mapvalidator.KeysAre(ticketAdditionalFieldKeyValidator())`,
+                  ],
                 },
               ],
             },


### PR DESCRIPTION
### Problem

The `jira` and `jira_server` actions on `sentry_alert` only expose `integration_id`, `project` and `issue_type`. Alerts migrated from the legacy `sentry_issue_alert` resource lose the fields used for triage routing and oncall filtering — components, labels, priority, and a service-account reporter.

On the legacy resource those were reachable through the raw-JSON `actions` escape hatch. `sentry_alert` has no equivalent, so there is currently no way to express them.

This is a schema exposure gap rather than a missing capability: `TicketingActionHandler.data_schema` already declares `additional_fields` as `additionalProperties: true`, and `TicketingIssueAlertHandler.get_additional_fields` splats those keys into the blob passed to `create_issue`.

Refs #669, #742, #595.

### Change

Adds to both `jira` and `jira_server`:

- `labels`, `components`, `priority`, `reporter`
- `additional_fields` — a `map(string)` passthrough for `customfield_*` and any built-in field not exposed directly

### Type choices

`labels` is a **String**, not a Set. Jira splits the value on commas:

```python
if labels := data.get("labels"):
    data["labels"] = [label.strip() for label in labels.split(",") if label.strip()]
```

(`jira/utils/create_issue_schema_transformers.py`, and the same in `jira_server/integration.py`.) A list would raise `AttributeError` at alert-fire time rather than at apply. This intentionally differs from the sibling `github` action, whose schema declares `labels` as an array — the schema description calls the difference out.

`components` is a **Set**, since Jira Server iterates the value for array-typed fields.

### Key validation

Keys in `additional_fields` are validated for two independent reasons, kept as separate functions because they have different lifetimes.

**1. Collision (permanent).** The generated `additionalFields` marshaller writes `AdditionalProperties` into the same JSON object *after* the typed fields, so a passthrough key silently overwrites its dedicated attribute. Unchecked, `additional_fields = { labels = "x" }` discards the `labels` attribute, Terraform reports `Provider produced inconsistent result after apply`, and the resource is orphaned in Sentry. This is provider-side serialization and is unrelated to any API behaviour.

**2. Casing (temporary).** Sentry's write path runs `camel_to_snake_case` recursively with no exemption for `additional_fields`, so `fixVersions` is stored as `fix_versions`. The read path deliberately exempts these keys (`TicketingActionHandler.serialize_data`), making this an upstream asymmetry rather than intended behaviour.

Only an *inserted underscore* actually breaks the field — Jira Cloud lowercases both sides when matching, so `UPPER` → `upper` still resolves. The check rejects exactly that case and names the working lowercase spelling. Jira Server matches `fieldId` exactly, so there it fails outright.

getsentry/sentry#122398 fixes this upstream by exempting nested keys under `additional_fields`. The check carries a TODO referencing it, and should be removed once that has shipped and is present in the minimum supported Sentry version — it still applies to self-hosted installs predating the fix.

### Verification

Built from source and run against a live Jira Cloud integration via `dev_overrides`:

- All six attributes apply and read back with no drift (`terraform plan` → `No changes.`)
- Sentry stores: `{"labels": "oncall,triage", "project": "10000", "priority": "3", "reporter": "...", "issuetype": "10001", "components": ["10001"], "fixversions": "10500", "customfield_10101": "sre-team"}`
- With the casing check disabled, `fixVersions` reproduces the inconsistent-result error and a permanent destroy/create loop on every apply
- With the collision check disabled, `additional_fields = { labels = ... }` silently overwrites the typed attribute and orphans the resource
- Raw API `POST` with `fixVersions` returns **HTTP 201** and stores `fix_versions` — no error surfaces at the API layer, which is why this is caught at plan time

Unit tests cover the validator rules, the Django `re_camel_case` parity of `camelToSnakeCase`, and the marshaller collision. No acceptance test is included: the alert acceptance suite runs against the maintainer's org and would need a Jira integration present.

`vsts` shares the same `TicketingActionHandler` path and has the same gap, but is intentionally left out of scope here.
