### PR TITLE
fix(alert): support event frequency count triggers

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1370,10 +1370,21 @@ Optional:
 
 Optional:
 
+- `event_frequency_count` (Attributes) Number of events seen by the workflow exceeds a threshold within an interval. (see [below for nested schema](#nestedatt--trigger_conditions--event_frequency_count))
 - `first_seen_event` (Attributes) A new issue is created. (see [below for nested schema](#nestedatt--trigger_conditions--first_seen_event))
 - `issue_resolved_trigger` (Attributes) An issue is resolved. (see [below for nested schema](#nestedatt--trigger_conditions--issue_resolved_trigger))
 - `reappeared_event` (Attributes) An issue escalates. (see [below for nested schema](#nestedatt--trigger_conditions--reappeared_event))
 - `regression_event` (Attributes) A resolved issue becomes unresolved. (see [below for nested schema](#nestedatt--trigger_conditions--regression_event))
+
+<a id="nestedatt--trigger_conditions--event_frequency_count"></a>
+### Nested Schema for `trigger_conditions.event_frequency_count`
+
+Required:
+
+- `interval` (String) The time period in which to evaluate the event count. Valid values are: `1m`, `5m`, `15m`, `1h`, `1d`, `1w`, and `30d`.
+- `value` (Number) The number of events that must be exceeded before the alert will fire.
+
+
 
 <a id="nestedatt--trigger_conditions--first_seen_event"></a>
 ### Nested Schema for `trigger_conditions.first_seen_event`

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1385,7 +1385,6 @@ Required:
 - `value` (Number) The number of events that must be exceeded before the alert will fire.
 
 
-
 <a id="nestedatt--trigger_conditions--first_seen_event"></a>
 ### Nested Schema for `trigger_conditions.first_seen_event`
 

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -101,7 +101,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemFirstSeenEvent](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -110,7 +110,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemIssueResolvedTrigger](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -119,7 +119,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemReappearedEvent](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("regression_event")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -128,9 +128,35 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemRegressionEvent](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("event_frequency_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
+						},
+						"event_frequency_count": schema.SingleNestedAttribute{
+							MarkdownDescription: "Number of events seen by the workflow exceeds a threshold within an interval.",
+							Optional:            true,
+							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemEventFrequencyCount](ctx),
+							Validators: []validator.Object{
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event")),
+							},
+							Attributes: map[string]schema.Attribute{
+								"value": schema.Int64Attribute{
+									MarkdownDescription: "The number of events that must be exceeded before the alert will fire.",
+									Required:            true,
+									CustomType:          supertypes.Int64Type{},
+									Validators: []validator.Int64{
+										int64validator.AtLeast(0),
+									},
+								},
+								"interval": tfutils.WithEnumStringAttribute(
+									schema.StringAttribute{
+										MarkdownDescription: "The time period in which to evaluate the event count.",
+										Required:            true,
+										CustomType:          supertypes.StringType{},
+									},
+									sentrydata.EventFrequencyStandardIntervals,
+								),
+							},
 						},
 					},
 				},
@@ -1318,6 +1344,7 @@ type AlertResourceModelTriggerConditionsItem struct {
 	IssueResolvedTrigger supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemIssueResolvedTrigger] `tfsdk:"issue_resolved_trigger"`
 	ReappearedEvent      supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemReappearedEvent]      `tfsdk:"reappeared_event"`
 	RegressionEvent      supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemRegressionEvent]      `tfsdk:"regression_event"`
+	EventFrequencyCount  supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemEventFrequencyCount]  `tfsdk:"event_frequency_count"`
 }
 
 type AlertResourceModelTriggerConditionsItemFirstSeenEvent struct {
@@ -1330,6 +1357,11 @@ type AlertResourceModelTriggerConditionsItemReappearedEvent struct {
 }
 
 type AlertResourceModelTriggerConditionsItemRegressionEvent struct {
+}
+
+type AlertResourceModelTriggerConditionsItemEventFrequencyCount struct {
+	Value    supertypes.Int64Value  `tfsdk:"value"`
+	Interval supertypes.StringValue `tfsdk:"interval"`
 }
 
 type AlertResourceModelActionFiltersItem struct {

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"math"
 	"slices"
 	"strconv"
 
@@ -704,6 +706,22 @@ func (r *AlertResource) getTriggerConditions(ctx context.Context, data AlertReso
 			outTriggerCondition.Type = "reappeared_event"
 		case triggerCondition.RegressionEvent.IsKnown():
 			outTriggerCondition.Type = "regression_event"
+		case triggerCondition.EventFrequencyCount.IsKnown():
+			in := triggerCondition.EventFrequencyCount.DiagsGet(ctx, diags)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			comparison := map[string]any{
+				"interval": in.Interval.Get(),
+				"value":    in.Value.Get(),
+			}
+
+			if err := outTriggerCondition.Comparison.FromOrganizationWorkflowTriggerConditionComparison1(comparison); err != nil {
+				diags.AddError("Failed to create event_frequency_count trigger condition", err.Error())
+				return nil, diags
+			}
+			outTriggerCondition.Type = "event_frequency_count"
 		}
 
 		outTriggerConditions = append(outTriggerConditions, outTriggerCondition)
@@ -730,6 +748,32 @@ func (r *AlertResource) getTriggerConditions(ctx context.Context, data AlertReso
 	}
 
 	return outTriggerConditions, diags
+}
+
+func parseEventFrequencyCountTriggerComparison(comparison map[string]any) (string, int64, error) {
+	interval, ok := comparison["interval"].(string)
+	if !ok {
+		return "", 0, fmt.Errorf("expected interval to be a string, got %T", comparison["interval"])
+	}
+
+	value, ok := comparison["value"].(float64)
+	if !ok {
+		return "", 0, fmt.Errorf("expected value to be a number, got %T", comparison["value"])
+	} else if value < 0 || value >= float64(math.MaxInt64) || math.Trunc(value) != value {
+		return "", 0, fmt.Errorf("expected value to be a non-negative integer, got %v", value)
+	}
+
+	if rawFilters, exists := comparison["filters"]; exists && rawFilters != nil {
+		filters, ok := rawFilters.([]any)
+		if !ok {
+			return "", 0, fmt.Errorf("expected filters to be a list, got %T", rawFilters)
+		}
+		if len(filters) > 0 {
+			return "", 0, fmt.Errorf("event_frequency_count filters are not supported")
+		}
+	}
+
+	return interval, int64(value), nil
 }
 
 func (r *AlertResource) getCreateJSONRequestBody(ctx context.Context, data AlertResourceModel) (*apiclient.CreateOrganizationWorkflowJSONRequestBody, diag.Diagnostics) {
@@ -829,6 +873,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			IssueResolvedTrigger: supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemIssueResolvedTrigger](ctx),
 			ReappearedEvent:      supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemReappearedEvent](ctx),
 			RegressionEvent:      supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemRegressionEvent](ctx),
+			EventFrequencyCount:  supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemEventFrequencyCount](ctx),
 		}
 		switch triggerCondition.Type {
 		case "first_seen_event":
@@ -842,6 +887,26 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			triggerConditions = append(triggerConditions, outTriggerCondition)
 		case "regression_event":
 			outTriggerCondition.RegressionEvent = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemRegressionEvent{})
+			triggerConditions = append(triggerConditions, outTriggerCondition)
+		case "event_frequency_count":
+			comparison, err := triggerCondition.Comparison.AsOrganizationWorkflowTriggerConditionComparison1()
+			if err != nil {
+				if _, boolErr := triggerCondition.Comparison.AsOrganizationWorkflowTriggerConditionComparison0(); boolErr == nil {
+					legacyTriggerConditions = append(legacyTriggerConditions, triggerCondition.Type)
+					continue
+				}
+				diags.AddError("Failed to parse event_frequency_count trigger condition", err.Error())
+				return diags
+			}
+			interval, value, err := parseEventFrequencyCountTriggerComparison(comparison)
+			if err != nil {
+				diags.AddError("Failed to parse event_frequency_count trigger condition", err.Error())
+				return diags
+			}
+			outTriggerCondition.EventFrequencyCount = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemEventFrequencyCount{
+				Interval: supertypes.NewStringValue(interval),
+				Value:    supertypes.NewInt64Value(value),
+			})
 			triggerConditions = append(triggerConditions, outTriggerCondition)
 		default:
 			legacyTriggerConditions = append(legacyTriggerConditions, triggerCondition.Type)

--- a/internal/provider/resource_alert_test.go
+++ b/internal/provider/resource_alert_test.go
@@ -307,6 +307,123 @@ func TestAccAlertResource_basic(t *testing.T) {
 	})
 }
 
+func TestParseEventFrequencyCountTriggerComparisonRejectsFilters(t *testing.T) {
+	_, _, err := parseEventFrequencyCountTriggerComparison(map[string]any{
+		"interval": "1m",
+		"value":    float64(1),
+		"filters":  []any{map[string]any{"key": "level"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "filters are not supported") {
+		t.Fatalf("expected unsupported filters error, got %v", err)
+	}
+}
+
+func TestAccAlertResource_eventFrequencyCountTriggerRoundTrip(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("tf-project")
+	alertName := acctest.RandomWithPrefix("tf-alert")
+	rn := "sentry_alert.test"
+	config := testAccAlertResourceEventFrequencyCountConfig(projectName, alertName)
+
+	var workflow apiclient.OrganizationWorkflow
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					stateCheckAlertExists(rn, &workflow),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("trigger_conditions"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"event_frequency_count": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"interval": knownvalue.StringExact("1m"),
+								"value":    knownvalue.Int64Exact(0),
+							}),
+						}),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("legacy_trigger_conditions"), knownvalue.Null()),
+				},
+				PostApplyFunc: func() {
+					requireEventFrequencyCountTriggerComparison(t, workflow)
+				},
+			},
+		},
+	})
+}
+
+func requireEventFrequencyCountTriggerComparison(t *testing.T, workflow apiclient.OrganizationWorkflow) {
+	t.Helper()
+
+	triggers, err := workflow.Triggers.AsOrganizationWorkflowTrigger()
+	if err != nil {
+		t.Fatalf("failed to parse workflow triggers: %v", err)
+	}
+	for _, condition := range triggers.Conditions {
+		if condition.Type != "event_frequency_count" {
+			continue
+		}
+
+		comparison, err := condition.Comparison.AsOrganizationWorkflowTriggerConditionComparison1()
+		if err != nil {
+			t.Fatalf("event_frequency_count comparison is not an object: %v", err)
+		}
+		if comparison["interval"] != "1m" || comparison["value"] != float64(0) {
+			t.Fatalf("unexpected event_frequency_count comparison: %#v", comparison)
+		}
+
+		return
+	}
+
+	t.Fatal("event_frequency_count trigger not found in workflow API response")
+}
+
+func testAccAlertResourceEventFrequencyCountConfig(projectName, alertName string) string {
+	return fmt.Sprintf(`
+		resource "sentry_project" "test" {
+			organization = "%[1]s"
+			teams        = ["%[2]s"]
+			name         = "%[3]s"
+			platform     = "go"
+		}
+
+		data "sentry_project_issue_stream_monitor" "test" {
+			organization = "%[1]s"
+			project      = sentry_project.test.slug
+		}
+
+		resource "sentry_alert" "test" {
+			organization      = "%[1]s"
+			name              = "%[4]s"
+			frequency_minutes = 1440
+			monitor_ids       = [data.sentry_project_issue_stream_monitor.test.id]
+
+			trigger_conditions = [
+				{
+				event_frequency_count = {
+					value    = 0
+					interval = "1m"
+				}
+				},
+			]
+
+			action_filters = [
+				{
+					logic_type = "all"
+					conditions = []
+					actions = [
+						{
+							email = {
+								target_type      = "issue_owners"
+								fallthrough_type = "AllMembers"
+							}
+						},
+					]
+				},
+			]
+		}
+	`, acctest.TestOrganization, acctest.TestTeam.Slug, projectName, alertName)
+}
+
 func testAccAlertResourceConfig(projectName, monitorName, name, opsgenieTeamName string) string {
 	return testAccMetricMonitorResourceConfig(projectName, monitorName, `
 		aggregate = "count()"

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -113,6 +113,31 @@ export default {
           computedOptionalRequired: "optional",
           attributes: [],
         },
+        {
+          name: "event_frequency_count",
+          type: "single_nested",
+          description:
+            "Number of events seen by the workflow exceeds a threshold within an interval.",
+          computedOptionalRequired: "optional",
+          attributes: [
+            {
+              name: "value",
+              type: "int64",
+              description:
+                "The number of events that must be exceeded before the alert will fire.",
+              computedOptionalRequired: "required",
+              validators: ["int64validator.AtLeast(0)"],
+            },
+            {
+              name: "interval",
+              type: "string",
+              description:
+                "The time period in which to evaluate the event count.",
+              computedOptionalRequired: "required",
+              enum: `sentrydata.EventFrequencyStandardIntervals`,
+            },
+          ],
+        },
       ]),
     },
     {


### PR DESCRIPTION
Add typed schema and API conversion for event_frequency_count trigger conditions used by issue alerts.

Serialize interval and value into the workflow trigger comparison and restore those fields into Terraform state. Reject unsupported filters explicitly instead of silently changing their meaning.

Include focused test coverage and regenerate the resource documentation.

This PR supersedes previous MR with a deliberately smaller scope limited to `event_frequency_count` trigger conditions.