### PR TITLE
chore: skip TestAccIssueAlertDataSource test as the API has been deprecated

### DIFF
--- a/internal/provider/data_source_issue_alert_test.go
+++ b/internal/provider/data_source_issue_alert_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccIssueAlertDataSource(t *testing.T) {
+	t.Skip("Deprecated")
+
 	rn := "sentry_issue_alert.test"
 	dsn := "data.sentry_issue_alert.test"
 	project := acctest.RandomWithPrefix("tf-project")


### PR DESCRIPTION
Skip issue alert data source test as the API no longer exists.