### PR TITLE
fix(alert): support percent sessions count triggers

### DIFF
--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -1378,6 +1378,7 @@ Optional:
 - `event_unique_user_frequency_count` (Attributes) Number of unique users affected by the workflow exceeds a threshold within an interval. (see [below for nested schema](#nestedatt--trigger_conditions--event_unique_user_frequency_count))
 - `first_seen_event` (Attributes) A new issue is created. (see [below for nested schema](#nestedatt--trigger_conditions--first_seen_event))
 - `issue_resolved_trigger` (Attributes) An issue is resolved. (see [below for nested schema](#nestedatt--trigger_conditions--issue_resolved_trigger))
+- `percent_sessions_count` (Attributes) Percentage of sessions affected by the workflow exceeds a threshold within an interval. (see [below for nested schema](#nestedatt--trigger_conditions--percent_sessions_count))
 - `reappeared_event` (Attributes) An issue escalates. (see [below for nested schema](#nestedatt--trigger_conditions--reappeared_event))
 - `regression_event` (Attributes) A resolved issue becomes unresolved. (see [below for nested schema](#nestedatt--trigger_conditions--regression_event))
 
@@ -1405,6 +1406,15 @@ Required:
 
 <a id="nestedatt--trigger_conditions--issue_resolved_trigger"></a>
 ### Nested Schema for `trigger_conditions.issue_resolved_trigger`
+
+
+<a id="nestedatt--trigger_conditions--percent_sessions_count"></a>
+### Nested Schema for `trigger_conditions.percent_sessions_count`
+
+Required:
+
+- `interval` (String) The time period in which to evaluate the percentage of affected sessions. Valid values are: `1m`, `5m`, `10m`, `30m`, and `1h`.
+- `value` (Number) The percentage of sessions affected that must be exceeded before the alert will fire.
 
 
 <a id="nestedatt--trigger_conditions--reappeared_event"></a>

--- a/internal/provider/resource_alert_gen.go
+++ b/internal/provider/resource_alert_gen.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	intresource "github.com/jianyuan/terraform-provider-sentry/internal/resource"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrydata"
 	"github.com/jianyuan/terraform-provider-sentry/internal/sentrytypes"
@@ -101,7 +103,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemFirstSeenEvent](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -110,7 +112,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemIssueResolvedTrigger](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -119,7 +121,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemReappearedEvent](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -128,7 +130,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemRegressionEvent](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count")),
 							},
 							Attributes: map[string]schema.Attribute{},
 						},
@@ -137,7 +139,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemEventFrequencyCount](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count")),
 							},
 							Attributes: map[string]schema.Attribute{
 								"value": schema.Int64Attribute{
@@ -163,7 +165,7 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							Optional:            true,
 							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemEventUniqueUserFrequencyCount](ctx),
 							Validators: []validator.Object{
-								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count")),
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("percent_sessions_count")),
 							},
 							Attributes: map[string]schema.Attribute{
 								"value": schema.Int64Attribute{
@@ -181,6 +183,33 @@ func (r *AlertResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 										CustomType:          supertypes.StringType{},
 									},
 									sentrydata.EventFrequencyStandardIntervals,
+								),
+							},
+						},
+						"percent_sessions_count": schema.SingleNestedAttribute{
+							MarkdownDescription: "Percentage of sessions affected by the workflow exceeds a threshold within an interval.",
+							Optional:            true,
+							CustomType:          supertypes.NewSingleNestedObjectTypeOf[AlertResourceModelTriggerConditionsItemPercentSessionsCount](ctx),
+							Validators: []validator.Object{
+								objectvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("first_seen_event"), path.MatchRelative().AtParent().AtName("issue_resolved_trigger"), path.MatchRelative().AtParent().AtName("reappeared_event"), path.MatchRelative().AtParent().AtName("regression_event"), path.MatchRelative().AtParent().AtName("event_frequency_count"), path.MatchRelative().AtParent().AtName("event_unique_user_frequency_count")),
+							},
+							Attributes: map[string]schema.Attribute{
+								"value": schema.Float64Attribute{
+									MarkdownDescription: "The percentage of sessions affected that must be exceeded before the alert will fire.",
+									Required:            true,
+									CustomType:          types.Float64Type,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+										float64validator.AtMost(100),
+									},
+								},
+								"interval": tfutils.WithEnumStringAttribute(
+									schema.StringAttribute{
+										MarkdownDescription: "The time period in which to evaluate the percentage of affected sessions.",
+										Required:            true,
+										CustomType:          supertypes.StringType{},
+									},
+									sentrydata.EventFrequencyPercentIntervals,
 								),
 							},
 						},
@@ -1377,6 +1406,7 @@ type AlertResourceModelTriggerConditionsItem struct {
 	RegressionEvent               supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemRegressionEvent]               `tfsdk:"regression_event"`
 	EventFrequencyCount           supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemEventFrequencyCount]           `tfsdk:"event_frequency_count"`
 	EventUniqueUserFrequencyCount supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemEventUniqueUserFrequencyCount] `tfsdk:"event_unique_user_frequency_count"`
+	PercentSessionsCount          supertypes.SingleNestedObjectValueOf[AlertResourceModelTriggerConditionsItemPercentSessionsCount]          `tfsdk:"percent_sessions_count"`
 }
 
 type AlertResourceModelTriggerConditionsItemFirstSeenEvent struct {
@@ -1398,6 +1428,11 @@ type AlertResourceModelTriggerConditionsItemEventFrequencyCount struct {
 
 type AlertResourceModelTriggerConditionsItemEventUniqueUserFrequencyCount struct {
 	Value    supertypes.Int64Value  `tfsdk:"value"`
+	Interval supertypes.StringValue `tfsdk:"interval"`
+}
+
+type AlertResourceModelTriggerConditionsItemPercentSessionsCount struct {
+	Value    types.Float64          `tfsdk:"value"`
 	Interval supertypes.StringValue `tfsdk:"interval"`
 }
 

--- a/internal/provider/resource_alert_impl.go
+++ b/internal/provider/resource_alert_impl.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jianyuan/terraform-plugin-framework-utils/fwdiag"
 	"github.com/jianyuan/terraform-provider-sentry/internal/apiclient"
 	"github.com/jianyuan/terraform-provider-sentry/internal/must"
@@ -740,6 +741,22 @@ func (r *AlertResource) getTriggerConditions(ctx context.Context, data AlertReso
 				return nil, diags
 			}
 			outTriggerCondition.Type = "event_unique_user_frequency_count"
+		case triggerCondition.PercentSessionsCount.IsKnown():
+			in := fwdiag.Merge(triggerCondition.PercentSessionsCount.Get(ctx))(&diags)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			comparison := map[string]any{
+				"interval": in.Interval.Get(),
+				"value":    in.Value.ValueFloat64(),
+			}
+
+			if err := outTriggerCondition.Comparison.FromOrganizationWorkflowTriggerConditionComparison1(comparison); err != nil {
+				diags.AddError("Failed to create percent_sessions_count trigger condition", err.Error())
+				return nil, diags
+			}
+			outTriggerCondition.Type = "percent_sessions_count"
 		}
 
 		outTriggerConditions = append(outTriggerConditions, outTriggerCondition)
@@ -818,6 +835,32 @@ func parseEventUniqueUserFrequencyCountTriggerComparison(comparison map[string]a
 	}
 
 	return interval, int64(value), nil
+}
+
+func parsePercentSessionsCountTriggerComparison(comparison map[string]any) (string, float64, error) {
+	interval, ok := comparison["interval"].(string)
+	if !ok {
+		return "", 0, fmt.Errorf("expected interval to be a string, got %T", comparison["interval"])
+	}
+
+	value, ok := comparison["value"].(float64)
+	if !ok {
+		return "", 0, fmt.Errorf("expected value to be a number, got %T", comparison["value"])
+	} else if value < 0 || value > 100 {
+		return "", 0, fmt.Errorf("expected value to be between 0 and 100, got %v", value)
+	}
+
+	if rawFilters, exists := comparison["filters"]; exists && rawFilters != nil {
+		filters, ok := rawFilters.([]any)
+		if !ok {
+			return "", 0, fmt.Errorf("expected filters to be a list, got %T", rawFilters)
+		}
+		if len(filters) > 0 {
+			return "", 0, fmt.Errorf("percent_sessions_count filters are not supported")
+		}
+	}
+
+	return interval, value, nil
 }
 
 func (r *AlertResource) getCreateJSONRequestBody(ctx context.Context, data AlertResourceModel) (*apiclient.CreateOrganizationWorkflowJSONRequestBody, diag.Diagnostics) {
@@ -919,6 +962,7 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			RegressionEvent:               supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemRegressionEvent](ctx),
 			EventFrequencyCount:           supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemEventFrequencyCount](ctx),
 			EventUniqueUserFrequencyCount: supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemEventUniqueUserFrequencyCount](ctx),
+			PercentSessionsCount:          supertypes.NewSingleNestedObjectValueOfNull[AlertResourceModelTriggerConditionsItemPercentSessionsCount](ctx),
 		}
 		switch triggerCondition.Type {
 		case "first_seen_event":
@@ -971,6 +1015,26 @@ func (m *AlertResourceModel) Fill(ctx context.Context, data apiclient.Organizati
 			outTriggerCondition.EventUniqueUserFrequencyCount = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemEventUniqueUserFrequencyCount{
 				Interval: supertypes.NewStringValue(interval),
 				Value:    supertypes.NewInt64Value(value),
+			})
+			triggerConditions = append(triggerConditions, outTriggerCondition)
+		case "percent_sessions_count":
+			comparison, err := triggerCondition.Comparison.AsOrganizationWorkflowTriggerConditionComparison1()
+			if err != nil {
+				if _, boolErr := triggerCondition.Comparison.AsOrganizationWorkflowTriggerConditionComparison0(); boolErr == nil {
+					legacyTriggerConditions = append(legacyTriggerConditions, triggerCondition.Type)
+					continue
+				}
+				diags.AddError("Failed to parse percent_sessions_count trigger condition", err.Error())
+				return diags
+			}
+			interval, value, err := parsePercentSessionsCountTriggerComparison(comparison)
+			if err != nil {
+				diags.AddError("Failed to parse percent_sessions_count trigger condition", err.Error())
+				return diags
+			}
+			outTriggerCondition.PercentSessionsCount = supertypes.NewSingleNestedObjectValueOf(ctx, &AlertResourceModelTriggerConditionsItemPercentSessionsCount{
+				Interval: supertypes.NewStringValue(interval),
+				Value:    types.Float64Value(value),
 			})
 			triggerConditions = append(triggerConditions, outTriggerCondition)
 		default:

--- a/internal/provider/resource_alert_test.go
+++ b/internal/provider/resource_alert_test.go
@@ -329,6 +329,17 @@ func TestParseEventUniqueUserFrequencyCountTriggerComparisonRejectsFilters(t *te
 	}
 }
 
+func TestParsePercentSessionsCountTriggerComparisonRejectsFilters(t *testing.T) {
+	_, _, err := parsePercentSessionsCountTriggerComparison(map[string]any{
+		"interval": "10m",
+		"value":    17.2,
+		"filters":  []any{map[string]any{"key": "level"}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "filters are not supported") {
+		t.Fatalf("expected unsupported filters error, got %v", err)
+	}
+}
+
 func TestAccAlertResource_eventFrequencyCountTriggerRoundTrip(t *testing.T) {
 	projectName := acctest.RandomWithPrefix("tf-project")
 	alertName := acctest.RandomWithPrefix("tf-alert")
@@ -519,6 +530,112 @@ func testAccAlertResourceEventUniqueUserFrequencyCountConfig(projectName, alertN
 				event_unique_user_frequency_count = {
 					value    = 3
 					interval = "5m"
+				}
+				},
+			]
+
+			action_filters = [
+				{
+					logic_type = "all"
+					conditions = []
+					actions = [
+						{
+							email = {
+								target_type      = "issue_owners"
+								fallthrough_type = "AllMembers"
+							}
+						},
+					]
+				},
+			]
+		}
+	`, acctest.TestOrganization, acctest.TestTeam.Slug, projectName, alertName)
+}
+
+func TestAccAlertResource_percentSessionsCountTriggerRoundTrip(t *testing.T) {
+	projectName := acctest.RandomWithPrefix("tf-project")
+	alertName := acctest.RandomWithPrefix("tf-alert")
+	rn := "sentry_alert.test"
+	config := testAccAlertResourcePercentSessionsCountConfig(projectName, alertName)
+
+	var workflow apiclient.OrganizationWorkflow
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ConfigStateChecks: []statecheck.StateCheck{
+					stateCheckAlertExists(rn, &workflow),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("trigger_conditions"), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectPartial(map[string]knownvalue.Check{
+							"percent_sessions_count": knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"interval": knownvalue.StringExact("10m"),
+								"value":    knownvalue.Float64Exact(17.2),
+							}),
+						}),
+					})),
+					statecheck.ExpectKnownValue(rn, tfjsonpath.New("legacy_trigger_conditions"), knownvalue.Null()),
+				},
+				PostApplyFunc: func() {
+					requirePercentSessionsCountTriggerComparison(t, workflow)
+				},
+			},
+		},
+	})
+}
+
+func requirePercentSessionsCountTriggerComparison(t *testing.T, workflow apiclient.OrganizationWorkflow) {
+	t.Helper()
+
+	triggers, err := workflow.Triggers.AsOrganizationWorkflowTrigger()
+	if err != nil {
+		t.Fatalf("failed to parse workflow triggers: %v", err)
+	}
+	for _, condition := range triggers.Conditions {
+		if condition.Type != "percent_sessions_count" {
+			continue
+		}
+
+		comparison, err := condition.Comparison.AsOrganizationWorkflowTriggerConditionComparison1()
+		if err != nil {
+			t.Fatalf("percent_sessions_count comparison is not an object: %v", err)
+		}
+		if comparison["interval"] != "10m" || comparison["value"] != 17.2 {
+			t.Fatalf("unexpected percent_sessions_count comparison: %#v", comparison)
+		}
+
+		return
+	}
+
+	t.Fatal("percent_sessions_count trigger not found in workflow API response")
+}
+
+func testAccAlertResourcePercentSessionsCountConfig(projectName, alertName string) string {
+	return fmt.Sprintf(`
+		resource "sentry_project" "test" {
+			organization = "%[1]s"
+			teams        = ["%[2]s"]
+			name         = "%[3]s"
+			platform     = "go"
+		}
+
+		data "sentry_project_issue_stream_monitor" "test" {
+			organization = "%[1]s"
+			project      = sentry_project.test.slug
+		}
+
+		resource "sentry_alert" "test" {
+			organization      = "%[1]s"
+			name              = "%[4]s"
+			frequency_minutes = 1440
+			monitor_ids       = [data.sentry_project_issue_stream_monitor.test.id]
+
+			trigger_conditions = [
+				{
+				percent_sessions_count = {
+					value    = 17.2
+					interval = "10m"
 				}
 				},
 			]

--- a/internal/providergen/resources/alert.ts
+++ b/internal/providergen/resources/alert.ts
@@ -163,6 +163,34 @@ export default {
             },
           ],
         },
+        {
+          name: "percent_sessions_count",
+          type: "single_nested",
+          description:
+            "Percentage of sessions affected by the workflow exceeds a threshold within an interval.",
+          computedOptionalRequired: "optional",
+          attributes: [
+            {
+              name: "value",
+              type: "float64",
+              description:
+                "The percentage of sessions affected that must be exceeded before the alert will fire.",
+              computedOptionalRequired: "required",
+              validators: [
+                "float64validator.AtLeast(0)",
+                "float64validator.AtMost(100)",
+              ],
+            },
+            {
+              name: "interval",
+              type: "string",
+              description:
+                "The time period in which to evaluate the percentage of affected sessions.",
+              computedOptionalRequired: "required",
+              enum: `sentrydata.EventFrequencyPercentIntervals`,
+            },
+          ],
+        },
       ]),
     },
     {

--- a/internal/sentrydata/generate.py
+++ b/internal/sentrydata/generate.py
@@ -619,17 +619,21 @@ async def parse_event_frequency(
 ) -> dict[str, Variable[Any]]:
     data = await get_file_data(client, "src/sentry/rules/conditions/event_frequency.py")
     out: dict[str, Variable[Any]] = {}
+    interval_vars = {
+        "STANDARD_INTERVALS": "EventFrequencyStandardIntervals",
+        "PERCENT_INTERVALS": "EventFrequencyPercentIntervals",
+    }
     for node in ast.walk(data.tree):
         match node:
             case ast.AnnAssign(
-                target=ast.Name(id="STANDARD_INTERVALS"),
+                target=ast.Name(id=name),
                 value=ast.Dict(keys=keys),
-            ):
+            ) if name in interval_vars:
                 result_intervals: list[str] = []
                 for key in keys:
                     assert isinstance(key, ast.Constant)
                     result_intervals.append(key.value)
-                out["EventFrequencyStandardIntervals"] = Variable(
+                out[interval_vars[name]] = Variable(
                     github_url=data.github_url, data=result_intervals
                 )
             case _:

--- a/internal/sentrydata/sentrydata.go
+++ b/internal/sentrydata/sentrydata.go
@@ -1185,3 +1185,12 @@ var EventFrequencyStandardIntervals = []string{
 	"1w",
 	"30d",
 }
+
+// https://github.com/getsentry/sentry/blob/master/src/sentry/rules/conditions/event_frequency.py
+var EventFrequencyPercentIntervals = []string{
+	"1m",
+	"5m",
+	"10m",
+	"30m",
+	"1h",
+}


### PR DESCRIPTION
## Summary

Add support for `percent_sessions_count` trigger conditions with fractional values and Sentry-supported intervals.

This enables managing existing alerts using this condition without apply failures.

Filters and other percentage-based conditions are intentionally out of scope.